### PR TITLE
[678] Trading Bar is not closed when clicking on Back to Markets in market page

### DIFF
--- a/src/pages/Market/Market.tsx
+++ b/src/pages/Market/Market.tsx
@@ -5,7 +5,7 @@ import dayjs from 'dayjs';
 import isNull from 'lodash/isNull';
 import { getMarket, setChartViewType } from 'redux/ducks/market';
 import { reset } from 'redux/ducks/trade';
-import { openTradeForm } from 'redux/ducks/ui';
+import { closeRightSidebar, openTradeForm } from 'redux/ducks/ui';
 
 import { ArrowLeftIcon } from 'assets/icons';
 
@@ -101,6 +101,20 @@ const Market = () => {
     network
   );
 
+  function resetTrade() {
+    dispatch(reset());
+  }
+
+  function closeTradeSidebar() {
+    dispatch(closeRightSidebar());
+  }
+
+  function backToMarkets() {
+    resetTrade();
+    closeTradeSidebar();
+    history.push('/');
+  }
+
   return (
     <div className="pm-p-market">
       <SEO
@@ -134,7 +148,7 @@ const Market = () => {
         <Button
           variant="outline"
           size="sm"
-          onClick={() => history.push('/')}
+          onClick={() => backToMarkets()}
           aria-label="Back to Markets"
         >
           <ArrowLeftIcon />


### PR DESCRIPTION
# [Trading Bar is not closed when clicking on `Back to Markets` in market page](https://app.shortcut.com/polkamarkets/story/678/trading-bar-is-not-closed-when-clicking-on-back-to-markets-in-market-page)

Currently, when clicking on the `Back to markets` action, the sidebar (and its respective form) remains with the selected market state, causing an inconsistency between the list of markets and the content of the sidebar.

This change will clear the sidebar state before returning to the markets page.

## ⚡ Changelog

| _Unit_ | 🟢 Added | 🟡 Changed | 🔴 Removed |
| - | - | - | - |
| 🟡 Market | | Resets sidebar state in `Back to markets` action  | |

### Footnotes

> `useHook()` is related to React JS hooks, located on `src/hooks/` path;
> 
> `<Component />`/ `<Component [prop=value] />` is related to React JS components, located on `src/components/` path;
> 
> `module()` is related to modules located on `src/utils/` or anywhere else on the app that provides some usefull shared resource;