### PR TITLE
[677] Market List - Apply React Virtuoso

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "react-router-dom": "^5.2.0",
     "react-scripts": "^4.0.3",
     "react-tradingview-widget": "^1.3.2",
-    "react-virtuoso": "^2.13.2",
+    "react-virtuoso": "^2.18.0",
     "recharts": "^2.1.9",
     "redux-thunk": "^2.3.0",
     "reselect": "^4.0.0",

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -1,9 +1,15 @@
 // import Text from '../Text';
 // import FooterLinks from './FooterLinks';
 // import FooterMenu from './FooterMenu';
+import { useFooterVisibility } from 'hooks';
+
 import FooterTerms from './FooterTerms';
 
 function Footer() {
+  const { visible } = useFooterVisibility();
+
+  if (!visible) return null;
+
   return (
     <div className="pm-l-footer">
       <FooterTerms />

--- a/src/components/Footer/FooterTerms.tsx
+++ b/src/components/Footer/FooterTerms.tsx
@@ -11,7 +11,6 @@ function FooterTerms() {
         className="pm-l-footer__terms-text-secondary"
         style={{
           textAlign: 'center',
-          paddingBottom: '1rem',
           whiteSpace: 'pre-line'
         }}
       >

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -31,15 +31,17 @@ function Layout({ children }: LayoutProps) {
           <Sidebar />
         </nav>
         <ScrollableArea
-          className={cn('flex-column justify-space-between', {
+          className={cn({
             'pm-l-layout__scrollable-area--with-alert': hasAlertNotification,
             'pm-l-layout__scrollable-area': !hasAlertNotification
           })}
         >
-          <main className="pm-l-layout__main">{children}</main>
-          <footer className="pm-l-layout__footer">
-            <Footer />
-          </footer>
+          <main className="pm-l-layout__main">
+            {children}
+            <footer className="pm-l-layout__footer">
+              <Footer />
+            </footer>
+          </main>
         </ScrollableArea>
         <ScrollableArea>
           <aside className="pm-l-layout__aside">

--- a/src/components/Market/MarketOutcomes.tsx
+++ b/src/components/Market/MarketOutcomes.tsx
@@ -144,7 +144,7 @@ function MarketOutcomesItem({ market, outcome }: MarketOutcomesItemProps) {
             data={chartData}
             color={marketPriceUp ? 'green' : 'red'}
             width={48}
-            height={24}
+            height={30}
           />
         </div>
       )}

--- a/src/components/Market/MarketOutcomes.tsx
+++ b/src/components/Market/MarketOutcomes.tsx
@@ -16,9 +16,10 @@ import {
   WarningIcon
 } from 'assets/icons';
 
+import { Area } from 'components/plots';
+
 import { useAppDispatch, useAppSelector } from 'hooks';
 
-import MiniAreaChart from '../MiniAreaChart';
 import Text from '../Text';
 
 const outcomeStates = {
@@ -138,10 +139,12 @@ function MarketOutcomesItem({ market, outcome }: MarketOutcomesItemProps) {
         </div>
       ) : (
         <div className="pm-c-market-outcomes__item-chart">
-          <MiniAreaChart
-            serie={chartData}
-            color={marketPriceUp ? 'success' : 'danger'}
+          <Area
+            id={`${marketId}-${id}-${title}`}
+            data={chartData}
+            color={marketPriceUp ? 'green' : 'red'}
             width={48}
+            height={24}
           />
         </div>
       )}

--- a/src/components/MarketList/MarketListAsync.tsx
+++ b/src/components/MarketList/MarketListAsync.tsx
@@ -12,6 +12,7 @@ import { useAppSelector } from 'hooks';
 
 import PredictionCard from '../PredictionCard';
 import Text from '../Text';
+import VirtualizedList from '../VirtualizedList';
 
 type MarketListAsyncProps = {
   id: string;
@@ -43,8 +44,10 @@ const MarketListAsync = ({
 
   if (isLoading[id])
     return (
-      <div className="pm-market__loading" style={{ paddingTop: '5rem' }}>
-        <span className="spinner--primary" />
+      <div className="pm-c-market-list__empty-state">
+        <div className="pm-c-market-list__empty-state__body">
+          <span className="spinner--primary" />
+        </div>
       </div>
     );
 
@@ -90,16 +93,17 @@ const MarketListAsync = ({
   }
 
   return (
-    <ul className="market-list">
-      {markets.map(market => (
-        <li
-          className="market-list__item"
-          key={`${market.id}-${market.networkId}`}
-        >
-          <PredictionCard market={market} />
-        </li>
-      ))}
-    </ul>
+    <div className="pm-c-market-list">
+      <VirtualizedList
+        height="100%"
+        data={markets}
+        itemContent={(_index, market) => (
+          <div className="pm-c-market-list__item">
+            <PredictionCard market={market} />
+          </div>
+        )}
+      />
+    </div>
   );
 };
 

--- a/src/components/MarketList/MarketListAsync.tsx
+++ b/src/components/MarketList/MarketListAsync.tsx
@@ -1,4 +1,4 @@
-import { useEffect, memo } from 'react';
+import { useEffect, memo, useCallback } from 'react';
 
 import isEmpty from 'lodash/isEmpty';
 import { Market } from 'models/market';
@@ -8,7 +8,7 @@ import { InfoIcon } from 'assets/icons';
 
 import { Button } from 'components/Button';
 
-import { useAppSelector } from 'hooks';
+import { useAppSelector, useFooterVisibility } from 'hooks';
 
 import PredictionCard from '../PredictionCard';
 import Text from '../Text';
@@ -28,6 +28,7 @@ const MarketListAsync = ({
   markets
 }: MarketListAsyncProps) => {
   const dispatch = useAppDispatch();
+  const { show, hide } = useFooterVisibility();
   const { isLoading, error } = useAppSelector(state => state.markets);
 
   useEffect(() => {
@@ -36,11 +37,23 @@ const MarketListAsync = ({
     }
   }, [dispatch, asyncAction, filterBy]);
 
-  function refreshMarkets() {
+  useEffect(() => {
+    if (!isEmpty(markets)) {
+      hide();
+    }
+    return () => show();
+  }, [dispatch, markets, hide, show]);
+
+  const refreshMarkets = useCallback(() => {
     if (!isEmpty(filterBy)) {
       dispatch(asyncAction(filterBy));
     }
-  }
+  }, [asyncAction, dispatch, filterBy]);
+
+  const setFooterVisibility = useCallback(
+    (atBottom: boolean) => (atBottom ? show() : hide()),
+    [hide, show]
+  );
 
   if (isLoading[id])
     return (
@@ -102,6 +115,7 @@ const MarketListAsync = ({
             <PredictionCard market={market} />
           </div>
         )}
+        atBottom={atBottom => setFooterVisibility(atBottom)}
       />
     </div>
   );

--- a/src/components/PredictionCard/PredictionCard.tsx
+++ b/src/components/PredictionCard/PredictionCard.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { Link } from 'react-router-dom';
 
 import { Market as MarketInterface } from 'models/market';
@@ -37,6 +38,4 @@ function PredictionCard({ market }: PredictionCardProps) {
   );
 }
 
-PredictionCard.displayName = 'PredictionCard';
-
-export default PredictionCard;
+export default memo(PredictionCard);

--- a/src/components/VirtualizedList/VirtualizedList.tsx
+++ b/src/components/VirtualizedList/VirtualizedList.tsx
@@ -1,17 +1,33 @@
-import { ReactNode } from 'react';
+import { ReactNode, useState, useEffect } from 'react';
 import { Virtuoso } from 'react-virtuoso';
 
 type VirtualizedListProps<T> = {
   height: number | string;
   data?: T[];
   itemContent: (_index: number, _item: T) => ReactNode;
+  atBottom?: (_atBottom: boolean) => void;
 };
 
 function VirtualizedList<T>({
   height,
-  data,
-  itemContent
+  data = [],
+  itemContent,
+  atBottom
 }: VirtualizedListProps<T>) {
+  const [visibleRange, setVisibleRange] = useState({
+    startIndex: 0,
+    endIndex: 0
+  });
+
+  const lastIndex = data.length - 1;
+
+  const isAtBottom =
+    visibleRange.startIndex <= lastIndex && lastIndex <= visibleRange.endIndex;
+
+  useEffect(() => {
+    atBottom?.(isAtBottom);
+  }, [atBottom, isAtBottom]);
+
   return (
     <Virtuoso
       style={{
@@ -19,6 +35,7 @@ function VirtualizedList<T>({
       }}
       data={data}
       itemContent={itemContent}
+      rangeChanged={setVisibleRange}
     />
   );
 }

--- a/src/components/VirtualizedList/VirtualizedList.tsx
+++ b/src/components/VirtualizedList/VirtualizedList.tsx
@@ -1,0 +1,26 @@
+import { ReactNode } from 'react';
+import { Virtuoso } from 'react-virtuoso';
+
+type VirtualizedListProps<T> = {
+  height: number | string;
+  data?: T[];
+  itemContent: (_index: number, _item: T) => ReactNode;
+};
+
+function VirtualizedList<T>({
+  height,
+  data,
+  itemContent
+}: VirtualizedListProps<T>) {
+  return (
+    <Virtuoso
+      style={{
+        height
+      }}
+      data={data}
+      itemContent={itemContent}
+    />
+  );
+}
+
+export default VirtualizedList;

--- a/src/components/VirtualizedList/index.tsx
+++ b/src/components/VirtualizedList/index.tsx
@@ -1,0 +1,3 @@
+import VirtualizedList from './VirtualizedList';
+
+export default VirtualizedList;

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -69,6 +69,7 @@ import ToastNotification from './ToastNotification';
 import ToggleSwitch from './ToggleSwitch';
 import Tooltip from './Tooltip';
 import TradeForm from './TradeForm';
+import VirtualizedList from './VirtualizedList';
 import WalletInfo from './WalletInfo';
 
 export {
@@ -149,5 +150,6 @@ export {
   ButtonGroup,
   ToggleSwitch,
   TradeForm,
+  VirtualizedList,
   WalletInfo
 };

--- a/src/components/plots/Area/Area.tsx
+++ b/src/components/plots/Area/Area.tsx
@@ -46,7 +46,8 @@ function Area({ id, width = 100, height = 50, data, color }: AreaProps) {
       <RechartsArea
         type="linear"
         dataKey="y"
-        stroke={`${colorVariant.stroke}57`}
+        strokeWidth={1.7}
+        stroke={colorVariant.stroke}
         fillOpacity={1}
         fill={`url(#${id})`}
         isAnimationActive={false}

--- a/src/components/plots/Area/Area.tsx
+++ b/src/components/plots/Area/Area.tsx
@@ -1,7 +1,9 @@
+import { useMemo } from 'react';
+
 import { AreaChart, Area as RechartsArea } from 'recharts';
 
 import { AreaDataPoint } from './Area.type';
-import { colorVariants } from './Area.util';
+import { colorVariants, minMaxScaler } from './Area.util';
 
 type AreaProps = {
   id: string;
@@ -14,11 +16,13 @@ type AreaProps = {
 function Area({ id, width = 100, height = 50, data, color }: AreaProps) {
   const colorVariant = colorVariants[color];
 
+  const minMaxScaledData = useMemo(() => minMaxScaler(data), [data]);
+
   return (
     <AreaChart
       width={width}
       height={height}
-      data={data}
+      data={minMaxScaledData}
       margin={{
         top: 0,
         right: 0,

--- a/src/components/plots/Area/Area.tsx
+++ b/src/components/plots/Area/Area.tsx
@@ -1,0 +1,57 @@
+import { AreaChart, Area as RechartsArea } from 'recharts';
+
+import { AreaDataPoint } from './Area.type';
+import { colorVariants } from './Area.util';
+
+type AreaProps = {
+  id: string;
+  width?: number;
+  height?: number;
+  data: AreaDataPoint[];
+  color: 'green' | 'red';
+};
+
+function Area({ id, width = 100, height = 50, data, color }: AreaProps) {
+  const colorVariant = colorVariants[color];
+
+  return (
+    <AreaChart
+      width={width}
+      height={height}
+      data={data}
+      margin={{
+        top: 0,
+        right: 0,
+        left: 0,
+        bottom: 0
+      }}
+      style={{
+        cursor: 'pointer'
+      }}
+    >
+      <defs>
+        <linearGradient id={id} x1="0" y1="0" x2="0" y2="1">
+          <stop
+            offset="5%"
+            stopColor={colorVariant.startStop}
+            stopOpacity={0.43}
+          />
+          <stop
+            offset="95%"
+            stopColor={colorVariant.endStop}
+            stopOpacity={0.1}
+          />
+        </linearGradient>
+      </defs>
+      <RechartsArea
+        type="linear"
+        dataKey="y"
+        stroke={`${colorVariant.stroke}57`}
+        fillOpacity={1}
+        fill={`url(#${id})`}
+      />
+    </AreaChart>
+  );
+}
+
+export default Area;

--- a/src/components/plots/Area/Area.tsx
+++ b/src/components/plots/Area/Area.tsx
@@ -49,6 +49,7 @@ function Area({ id, width = 100, height = 50, data, color }: AreaProps) {
         stroke={`${colorVariant.stroke}57`}
         fillOpacity={1}
         fill={`url(#${id})`}
+        isAnimationActive={false}
       />
     </AreaChart>
   );

--- a/src/components/plots/Area/Area.type.ts
+++ b/src/components/plots/Area/Area.type.ts
@@ -1,0 +1,12 @@
+import { Dayjs } from 'dayjs';
+
+export type AreaColor = {
+  startStop: string;
+  endStop: string;
+  stroke: string;
+};
+
+export type AreaDataPoint = {
+  x: Dayjs;
+  y: number;
+};

--- a/src/components/plots/Area/Area.util.ts
+++ b/src/components/plots/Area/Area.util.ts
@@ -1,5 +1,4 @@
-/* eslint-disable import/prefer-default-export */
-import { AreaColor } from './Area.type';
+import { AreaColor, AreaDataPoint } from './Area.type';
 
 export const colorVariants: { [key: string]: AreaColor } = {
   green: {
@@ -13,3 +12,15 @@ export const colorVariants: { [key: string]: AreaColor } = {
     stroke: '#ef4444'
   }
 };
+
+export function minMaxScaler(data: AreaDataPoint[]) {
+  const values = data.map(point => point.y);
+
+  const max = Math.max(...values);
+  const min = Math.min(...values);
+
+  return data.map(point => ({
+    ...point,
+    y: max - min === 0 ? 1 : (point.y - min) / (max - min)
+  }));
+}

--- a/src/components/plots/Area/Area.util.ts
+++ b/src/components/plots/Area/Area.util.ts
@@ -1,0 +1,15 @@
+/* eslint-disable import/prefer-default-export */
+import { AreaColor } from './Area.type';
+
+export const colorVariants: { [key: string]: AreaColor } = {
+  green: {
+    startStop: '#46d39a',
+    endStop: '#46d39a',
+    stroke: '#46d39a'
+  },
+  red: {
+    startStop: '#ef4444',
+    endStop: '#ef4444',
+    stroke: '#ef4444'
+  }
+};

--- a/src/components/plots/Area/index.tsx
+++ b/src/components/plots/Area/index.tsx
@@ -1,0 +1,3 @@
+import Area from './Area';
+
+export default Area;

--- a/src/components/plots/index.tsx
+++ b/src/components/plots/index.tsx
@@ -1,0 +1,4 @@
+/* eslint-disable import/prefer-default-export */
+import Area from './Area';
+
+export { Area };

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -23,3 +23,4 @@ export { default as usePortal } from './usePortal';
 export { default as usePrevious } from './usePrevious';
 export { default as useClickaway } from './useClickaway';
 export { default as useTrapfocus } from './useTrapfocus';
+export { default as useFooterVisibility } from './useFooterVisibility';

--- a/src/hooks/useFooterVisibility/index.ts
+++ b/src/hooks/useFooterVisibility/index.ts
@@ -1,0 +1,3 @@
+import useFooterVisibility from './useFooterVisibility';
+
+export default useFooterVisibility;

--- a/src/hooks/useFooterVisibility/useFooterVisibility.tsx
+++ b/src/hooks/useFooterVisibility/useFooterVisibility.tsx
@@ -1,0 +1,31 @@
+import create from 'zustand';
+import shallow from 'zustand/shallow';
+
+import { FooterVisibilityStore } from './useFooterVisibility.type';
+
+const footerVisibilityStore = create<FooterVisibilityStore>(set => ({
+  visible: true,
+  show() {
+    set({
+      visible: true
+    });
+  },
+  hide() {
+    set({
+      visible: false
+    });
+  }
+}));
+
+export default function useFooterVisibility() {
+  const controls = footerVisibilityStore(
+    store => ({
+      show: store.show,
+      hide: store.hide,
+      visible: store.visible
+    }),
+    shallow
+  );
+
+  return controls;
+}

--- a/src/hooks/useFooterVisibility/useFooterVisibility.type.ts
+++ b/src/hooks/useFooterVisibility/useFooterVisibility.type.ts
@@ -1,0 +1,5 @@
+export type FooterVisibilityStore = {
+  visible: boolean;
+  show: () => void;
+  hide: () => void;
+};

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -25,21 +25,17 @@ function Home() {
   );
 
   return (
-    <div className="pm-home">
-      <div className="pm-home__content">
-        <HomeMobileInfo />
-        <HomeCategories />
-        <HomeTabs
-          openMarkets={openMarkets}
-          closedMarkets={closedMarkets}
-          resolvedMarkets={resolvedMarkets}
-          favoritesMarkets={favoritesMarkets}
-        />
-      </div>
+    <div className="pm-p-home">
+      <HomeMobileInfo />
+      <HomeCategories />
+      <HomeTabs
+        openMarkets={openMarkets}
+        closedMarkets={closedMarkets}
+        resolvedMarkets={resolvedMarkets}
+        favoritesMarkets={favoritesMarkets}
+      />
     </div>
   );
 }
-
-Home.displayName = 'Home';
 
 export default Home;

--- a/src/pages/Home/HomeCategories.tsx
+++ b/src/pages/Home/HomeCategories.tsx
@@ -6,7 +6,7 @@ function HomeCategories() {
   const categories = useCategories();
 
   return (
-    <ul className="pm-home__categories">
+    <ul className="pm-p-home__categories">
       {categories?.map(category => (
         <li key={category.title}>
           <Category

--- a/src/pages/Home/HomeMobileInfo.tsx
+++ b/src/pages/Home/HomeMobileInfo.tsx
@@ -2,7 +2,7 @@ import { AlertMini } from 'components';
 
 function HomeMobileInfo() {
   return (
-    <div className="pm-home__mobile-info">
+    <div className="pm-p-home__mobile-info">
       <AlertMini
         variant="information"
         description="Our mobile version is read-only, you're only allowed to watch the markets. If you want to
@@ -11,7 +11,5 @@ function HomeMobileInfo() {
     </div>
   );
 }
-
-HomeMobileInfo.displayName = 'HomeMobileInfo';
 
 export default HomeMobileInfo;

--- a/src/styles/abstracts/variables/components/_market-list.scss
+++ b/src/styles/abstracts/variables/components/_market-list.scss
@@ -9,4 +9,4 @@ $market-list-themes: (
   )
 ) !default;
 
-$market-list-transitions: all 0.2s ease-in-out !default;
+$market-list-transitions: fill, color 0.2s ease-in-out !default;

--- a/src/styles/components/_market-list.scss
+++ b/src/styles/components/_market-list.scss
@@ -1,11 +1,10 @@
-.market-list {
-  @include flex-column;
-  gap: 2rem;
-
+.pm-c-market-list {
   height: 100%;
-  width: 100%;
+  margin: px-to-rem(10px) px-to-rem(0px);
 
-  margin: 1rem 0rem;
+  &__item {
+    padding-bottom: px-to-rem(20px);
+  }
 }
 
 .pm-c-market-list__empty-state,
@@ -14,15 +13,14 @@
     width: 100%;
     height: auto;
 
-    padding: 5.9rem 2rem;
+    padding: px-to-rem(50px) px-to-rem(20px);
+    margin: px-to-rem(10px) px-to-rem(0px);
 
     border: 0.1rem solid themed('state-info-border-color');
     border-radius: 0.4rem;
-    transition: $market-list-transitions;
 
     &__body {
-      @include flex-column(center, center);
-      gap: 1.2rem;
+      @include flex-column(center, center, px-to-rem(12px));
 
       svg {
         fill: $primary-500;
@@ -45,6 +43,6 @@
 
   &__actions {
     @extend .pm-c-market-list__empty-state__body;
-    padding: 2rem 0rem;
+    padding: px-to-rem(20px) px-to-rem(0px);
   }
 }

--- a/src/styles/components/_market-list.scss
+++ b/src/styles/components/_market-list.scss
@@ -1,6 +1,6 @@
 .pm-c-market-list {
   height: 100%;
-  margin: px-to-rem(10px) px-to-rem(0px);
+  margin-top: px-to-rem(10px);
 
   &__item {
     padding-bottom: px-to-rem(20px);

--- a/src/styles/components/_tabs.scss
+++ b/src/styles/components/_tabs.scss
@@ -3,7 +3,7 @@
     @include flex-column;
     gap: 1.6rem;
 
-    height: fit-content;
+    height: 100%;
 
     &__header {
       @include flex-row(space-between, center);

--- a/src/styles/layout/_layout.scss
+++ b/src/styles/layout/_layout.scss
@@ -12,14 +12,14 @@
     grid-template-rows: auto 1fr auto;
 
     background-color: themed('background-color');
-    transition: all 0.2s ease-in-out 0s;
+    transition: background-color 0.2s ease-in-out 0s;
 
     &__header {
       grid-area: header;
       z-index: 1000;
 
       background-color: themed('background-color');
-      transition: all 0.2s ease-in-out 0s;
+      transition: background-color 0.2s ease-in-out 0s;
     }
 
     &__alert {
@@ -66,7 +66,7 @@
 
       width: 100%;
       background-color: themed('background-color');
-      transition: all 0.2s ease-in-out 0s;
+      transition: background-color 0.2s ease-in-out 0s;
     }
   }
 }

--- a/src/styles/layout/_layout.scss
+++ b/src/styles/layout/_layout.scss
@@ -7,7 +7,7 @@
     grid-template-areas:
       'nav header header'
       'nav main aside'
-      'nav footer aside';
+      'nav main aside';
     grid-template-columns: auto minmax(0, 1fr) auto;
     grid-template-rows: auto 1fr auto;
 
@@ -37,8 +37,11 @@
     &__main {
       grid-area: main;
 
+      display: grid;
+      grid-template-rows: 1fr auto;
+      padding: px-to-rem(8px) px-to-rem(24px) px-to-rem(12px) px-to-rem(24px);
+
       height: 100%;
-      padding: 2.4rem;
     }
 
     &__scrollable-area {
@@ -58,7 +61,8 @@
     }
 
     &__footer {
-      grid-area: footer;
+      grid-row-start: 2;
+      grid-row-end: 3;
 
       width: 100%;
       background-color: themed('background-color');

--- a/src/styles/layout/_layout.scss
+++ b/src/styles/layout/_layout.scss
@@ -1,6 +1,7 @@
 .pm-l-layout {
   @include themes($layout-themes) {
     display: grid;
+    height: 100%;
     max-width: 100%;
 
     grid-template-areas:
@@ -36,6 +37,7 @@
     &__main {
       grid-area: main;
 
+      height: 100%;
       padding: 2.4rem;
     }
 

--- a/src/styles/pages/_home.scss
+++ b/src/styles/pages/_home.scss
@@ -1,14 +1,12 @@
-.pm-home {
+.pm-p-home {
+  @include flex-column($gap: px-to-rem(24px));
+  height: 100%;
   width: 100%;
-  margin: 0rem auto;
-
-  display: grid;
-  grid-template-columns: 1fr auto;
+  margin: px-to-rem(0px) auto;
 
   &__mobile-info {
     @include flex-column(center, center);
-
-    margin: 1.6rem 0rem;
+    margin-top: px-to-rem(16px);
 
     @include breakpoint-to('md') {
       display: none;
@@ -20,33 +18,8 @@
 
     @include breakpoint-to('sm') {
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
-      gap: 2rem;
-
-      margin: 0 0rem 2.4rem 0rem;
+      grid-template-columns: repeat(auto-fit, minmax(px-to-rem(100px), 1fr));
+      gap: px-to-rem(20px);
     }
   }
-
-  &__content {
-    grid-column: 1;
-  }
-
-  &__sidebar {
-    grid-column: 2;
-  }
-}
-
-.navigation {
-  display: flex;
-  flex-direction: row;
-
-  justify-content: space-between;
-}
-
-.filters {
-  @include flex-row;
-
-  gap: 3.2rem;
-
-  height: fit-content;
 }

--- a/src/styles/pages/_market.scss
+++ b/src/styles/pages/_market.scss
@@ -46,6 +46,8 @@
       grid-template-rows: auto auto auto auto auto auto;
     }
 
+    height: fit-content;
+
     &__analytics {
       grid-area: analytics;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -14862,10 +14862,10 @@ react-transition-group@^4.0.0, react-transition-group@^4.4.0:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-react-virtuoso@^2.13.2:
-  version "2.13.2"
-  resolved "https://registry.yarnpkg.com/react-virtuoso/-/react-virtuoso-2.13.2.tgz#dc5403e57e3e5aec0f4fe222f61e152f2a7f8017"
-  integrity sha512-DuZpTCC0rY5SAKPHQoZPKX3xAYN2iAGcG3P1Z7JVjq/8727usIwpSwvXGomyCvBIC2DHBX4yX46nVZ97+C6Pkw==
+react-virtuoso@^2.18.0:
+  version "2.18.0"
+  resolved "https://registry.yarnpkg.com/react-virtuoso/-/react-virtuoso-2.18.0.tgz#42f8a7cb632aaf0bb2812bbbd4b5f2583d3d53ec"
+  integrity sha512-BxMW9as2dPOP4YFkry/oNjQMEn3cOgEjHLb7Fg8oubOgRAfiukp1Co41QFD9ZMXZBNBZNTI2E5BwC5pol31mTg==
   dependencies:
     "@virtuoso.dev/react-urx" "^0.2.12"
     "@virtuoso.dev/urx" "^0.2.12"


### PR DESCRIPTION
# [Market List - Apply React Virtuoso](https://app.shortcut.com/polkamarkets/story/677/market-list-apply-react-virtuoso)

Rendering performance improvements in the market list and outcome charts.

Charts that were previously built on top of the `apexcharts` library were rewritten using the `recharts` library.
Market list is [virtualized](https://www.patterns.dev/posts/virtual-lists/) using the `react-virtuoso` library.

### References
1. [https://www.patterns.dev/posts/virtual-lists/](https://www.patterns.dev/posts/virtual-lists/)

## ⚡ Changelog
<!-- What and why would be added, changed or removed after that pull request. -->
<!-- Remove changelog section if it has no items -->

| _Unit_ | 🟢 Added | 🟡 Changed | 🔴 Removed |
| - | - | - | - |
| 🟢 Area | Area chart using `recharts` library | | |
| 🟢 VirtualizedList | Virtualized list using `react-virtuoso` library | | |
| 🟢 useFooterVisibility | Stores `footer` visibility and export `show` / `hide` callbacks | | |
| 🟡 react-virtuoso | | Upgraded from `v2.13.2` to `v2.18.2` | |
| 🟡 MarketOucomes | | Replaces deprecated `MiniAreaChart` with `Area` plot component | |
| 🟡 PredictionCard | | Applies React `memo` | |
| 🟡 Tabs, Layout, Main | | Fills 100% of vertical available space | |
| 🟡 HomeStyles | | Removes unused classes and rewrites using flexbox layout | |
| 🟡 Home, HomeCategories, HomeMobileInfo | | Updates base style class | |
| 🟡 MarketListAsync | | Uses the new `VirtualizedList` component | |

### Footnotes
<!-- Remove footnotes subsection if it has no changelog and backlog items -->

> `useHook()` is related to React JS hooks, located on `src/hooks/` path;
> 
> `<Component />`/ `<Component [prop=value] />` is related to React JS components, located on `src/components/` path;
> 
> `module()` is related to modules located on `src/utils/` or anywhere else on the app that provides some usefull shared resource;
