### PR TITLE
[709] Round to 2 Decimal Numbers in Create Market POLK Modal

### DIFF
--- a/src/assets/icons/TWarningIcon.tsx
+++ b/src/assets/icons/TWarningIcon.tsx
@@ -10,8 +10,7 @@ function TWarningIcon({ size = 12, ...props }: Props) {
       height={size}
       viewBox="0 0 12 12"
       style={{
-        verticalAlign: 'middle',
-        fill: 'currentColor'
+        verticalAlign: 'middle'
       }}
       {...props}
     >

--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -1,3 +1,4 @@
+import { roundNumber } from 'helpers/math';
 import isUndefined from 'lodash/isUndefined';
 import { Line } from 'rc-progress';
 
@@ -62,7 +63,7 @@ function ProgressBar({ min, max, percent, color = 'blue' }: ProgressBarProps) {
                 fontWeight="semibold"
                 className="pm-c-progress-bar__current"
               >
-                {max * (percent / 100)}
+                {roundNumber(max * (percent / 100), 2)}
               </Text>
               {` / ${max}`}
             </>

--- a/src/pages/CreateMarket/CreateMarketBuyPolk.tsx
+++ b/src/pages/CreateMarket/CreateMarketBuyPolk.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
 
+import { roundNumber } from 'helpers/math';
+
 import { TwarningIcon } from 'assets/icons';
 
 import { Text, ProgressBar, Button } from 'components';
@@ -47,7 +49,7 @@ function CreateMarketBuyPolk({
               fontWeight="semibold"
               className="pm-p-create-market-buy-polk__amount"
             >
-              {`${requiredPolkBalance - polkBalance} POLK`}
+              {`${roundNumber(requiredPolkBalance - polkBalance, 2)} POLK`}
             </Text>
             {` to create markets.`}
           </>


### PR DESCRIPTION
# [Round to 2 Decimal Numbers in Create Market POLK Modal](https://app.shortcut.com/polkamarkets/story/709/round-to-2-decimal-numbers-in-create-market-polk-modal)

There is a minimum amount of `POLK` to create a market.

The progress (displayed in the interface) of the amount may appear with a higher number of decimal places than expected.

This will limit you to a maximum of `2` decimal places.

## ⚡ Changelog

| _Unit_ | 🟢 Added | 🟡 Changed | 🔴 Removed |
| - | - | - | - |
| 🟡 TWarningIcon |  | Removes `fill` default value |  |
| 🟡 ProgressBar |  | Rounds current progress to 2 decimal numbers |  |

### Footnotes

> `useHook()` is related to React JS hooks, located on `src/hooks/` path;
> 
> `<Component />`/ `<Component [prop=value] />` is related to React JS components, located on `src/components/` path;
> 
> `module()` is related to modules located on `src/utils/` or anywhere else on the app that provides some usefull shared resource;
