### PR TITLE
[801] Area charts with weird gradient background

### DIFF
--- a/src/components/Market/MarketOutcomes.tsx
+++ b/src/components/Market/MarketOutcomes.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react';
 
 import classNames from 'classnames';
 import { fromPriceChartToLineChartSeries } from 'helpers/chart';
+import kebabCase from 'lodash/kebabCase';
 import { Market, Outcome } from 'models/market';
 import { marketSelected } from 'redux/ducks/market';
 import { selectOutcome } from 'redux/ducks/trade';
@@ -140,7 +141,7 @@ function MarketOutcomesItem({ market, outcome }: MarketOutcomesItemProps) {
       ) : (
         <div className="pm-c-market-outcomes__item-chart">
           <Area
-            id={`${marketId}-${id}-${title}`}
+            id={`${marketId}-${id}-${kebabCase(title)}`}
             data={chartData}
             color={marketPriceUp ? 'green' : 'red'}
             width={48}


### PR DESCRIPTION
# [Area charts with weird gradient background](https://app.shortcut.com/polkamarkets/story/801/area-charts-with-weird-gradient-background)

## ⚡ Changelog

| _Unit_ | 🟢 Added | 🟡 Changed | 🔴 Removed |
| - | - | - | - |
| 🟡 `<MarketsOutcomes />` | | Converts outcome title to kebab case before use as `Area` id |  |

### Footnotes

> `useHook()` is related to React JS hooks, located on `src/hooks/` path;
> 
> `<Component />`/ `<Component [prop=value] />` is related to React JS components, located on `src/components/` path;
> 
> `module()` is related to modules located on `src/utils/` or anywhere else on the app that provides some usefull shared resource;
