### PR TITLE
[797] IFL - Host notaku under /docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "framer-motion": "^3.10.5",
     "geoip-country": "^4.0.76",
     "helmet": "^6.0.0",
+    "http-proxy-middleware": "^2.0.6",
     "humps": "^2.0.1",
     "lodash": "^4.17.21",
     "mockdate": "^3.0.5",

--- a/server/index.js
+++ b/server/index.js
@@ -3,6 +3,8 @@ require('dotenv').config();
 const express = require('express');
 const helmet = require('helmet');
 
+const { createProxyMiddleware } = require('http-proxy-middleware');
+
 const app = express();
 app.use(helmet.frameguard({ action: 'deny' }));
 
@@ -141,6 +143,18 @@ app.get('/markets/:slug', async (request, response) => {
     }
   });
 });
+
+const { REACT_APP_NOTAKU_URL } = process.env;
+
+if (REACT_APP_NOTAKU_URL) {
+  app.use(
+    '/docs',
+    createProxyMiddleware({
+      target: `${REACT_APP_NOTAKU_URL}`,
+      changeOrigin: true
+    })
+  );
+}
 
 app.use(express.static(path.resolve(__dirname, '..', 'build')));
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4011,6 +4011,13 @@
   resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz#0ea7b61496902b95890dc4c3a116b60cb8dae812"
   integrity sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ==
 
+"@types/http-proxy@^1.17.8":
+  version "1.17.9"
+  resolved "https://registry.yarnpkg.com/@types/http-proxy/-/http-proxy-1.17.9.tgz#7f0e7931343761efde1e2bf48c40f02f3f75705a"
+  integrity sha512-QsbSjA/fSk7xB+UXlCT3wHBy5ai9wOcNDWwZAtud+jXhwOM3l+EYZh8Lng4+/6n8uar0J7xILzqftJdJ/Wdfkw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/humps@^2.0.0":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/humps/-/humps-2.0.1.tgz#fc87ccbe59913240c3fdca5f0dd43cb9f073eb72"
@@ -11181,7 +11188,18 @@ http-proxy-middleware@0.19.1:
     lodash "^4.17.11"
     micromatch "^3.1.10"
 
-http-proxy@^1.17.0:
+http-proxy-middleware@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz#e1a4dd6979572c7ab5a4e4b55095d1f32a74963f"
+  integrity sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==
+  dependencies:
+    "@types/http-proxy" "^1.17.8"
+    http-proxy "^1.18.1"
+    is-glob "^4.0.1"
+    is-plain-obj "^3.0.0"
+    micromatch "^4.0.2"
+
+http-proxy@^1.17.0, http-proxy@^1.18.1:
   version "1.18.1"
   resolved "https://registry.yarnpkg.com/http-proxy/-/http-proxy-1.18.1.tgz#401541f0534884bbf95260334e72f88ee3976549"
   integrity sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==
@@ -11902,6 +11920,11 @@ is-plain-obj@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz#45e42e37fccf1f40da8e5f76ee21515840c09287"
   integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
+
+is-plain-obj@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-3.0.0.tgz#af6f2ea14ac5a646183a5bbdb5baabbc156ad9d7"
+  integrity sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==
 
 is-plain-object@5.0.0:
   version "5.0.0"


### PR DESCRIPTION
# [IFL - Host notaku under /docs](https://app.shortcut.com/polkamarkets/story/797/ifl-host-notaku-under-docs)

## ⚡ Changelog

| _Unit_ | 🟢 Added | 🟡 Changed | 🔴 Removed |
| - | - | - | - |
| 🟢 `http-proxy-middleware` | Provides proxy middleware to `Express` server |  |  |
| 🟡 `server/index.js` |  | Creates a proxy to host Notaku docs on `/docs` route |  |

### Footnotes
<!-- Remove footnotes subsection if it has no changelog and backlog items -->

> `useHook()` is related to React JS hooks, located on `src/hooks/` path;
> 
> `<Component />`/ `<Component [prop=value] />` is related to React JS components, located on `src/components/` path;
> 
> `module()` is related to modules located on `src/utils/` or anywhere else on the app that provides some usefull shared resource;
