### PR TITLE
[808] IFL - Change default sorting and filters in Markets list

### DIFF
--- a/src/contexts/filters/filters.util.ts
+++ b/src/contexts/filters/filters.util.ts
@@ -213,12 +213,12 @@ const filtersInitialState: FiltersState = {
         {
           label: 'Open',
           value: 'open',
-          selected: false
+          selected: true
         },
         {
           label: 'Closed',
           value: 'closed',
-          selected: false
+          selected: true
         },
         {
           label: 'Resolved',

--- a/src/pages/Home/HomeNav.tsx
+++ b/src/pages/Home/HomeNav.tsx
@@ -3,8 +3,8 @@ import { useHistory } from 'react-router-dom';
 
 import {
   setSearchQuery,
-  setSorter,
-  setSorterByEndingSoon
+  setSorter
+  // setSorterByEndingSoon
 } from 'redux/ducks/markets';
 import { closeRightSidebar } from 'redux/ducks/ui';
 
@@ -20,12 +20,12 @@ export default function HomeNav() {
   const dispatch = useAppDispatch();
   const history = useHistory();
 
-  const handleTouchedFilter = useCallback(
-    (touched: boolean) => {
-      dispatch(setSorterByEndingSoon(!touched));
-    },
-    [dispatch]
-  );
+  // const handleTouchedFilter = useCallback(
+  //   (touched: boolean) => {
+  //     dispatch(setSorterByEndingSoon(!touched));
+  //   },
+  //   [dispatch]
+  // );
 
   function handleSelectedFilter(filter: {
     value: string | number;
@@ -63,7 +63,7 @@ export default function HomeNav() {
         defaultOption="expiresAt"
         options={filters}
         onChange={handleSelectedFilter}
-        onTouch={handleTouchedFilter}
+        // onTouch={handleTouchedFilter}
         className="pm-p-home__navigation__actions"
       />
       <Feature name="regular">

--- a/src/pages/Home/HomeNav.tsx
+++ b/src/pages/Home/HomeNav.tsx
@@ -60,7 +60,7 @@ export default function HomeNav() {
       />
       <Filter
         description="Sort by"
-        defaultOption="volumeEur"
+        defaultOption="expiresAt"
         options={filters}
         onChange={handleSelectedFilter}
         onTouch={handleTouchedFilter}

--- a/src/redux/ducks/markets.ts
+++ b/src/redux/ducks/markets.ts
@@ -1,7 +1,7 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { environment } from 'config';
-import dayjs from 'dayjs';
-import inRange from 'lodash/inRange';
+// import dayjs from 'dayjs';
+// import inRange from 'lodash/inRange';
 import isEmpty from 'lodash/isEmpty';
 import omitBy from 'lodash/omitBy';
 import orderBy from 'lodash/orderBy';
@@ -281,21 +281,21 @@ export const marketsSelector = ({ state, filters }: MarketsSelectorArgs) => {
         )
       : true;
 
-  const filterByisEndingSoon = expiresAt =>
-    inRange(dayjs().diff(dayjs(expiresAt), 'hours'), -24, 1);
+  // const filterByisEndingSoon = expiresAt =>
+  //   inRange(dayjs().diff(dayjs(expiresAt), 'hours'), -24, 1);
 
   function sorted(markets: Market[]) {
     if (state.sorter.sortBy) {
-      if (state.sorterByEndingSoon) {
-        return [
-          ...markets.filter(market => filterByisEndingSoon(market.expiresAt)),
-          ...orderBy(
-            markets.filter(market => !filterByisEndingSoon(market.expiresAt)),
-            [state.sorter.value],
-            [state.sorter.sortBy]
-          )
-        ];
-      }
+      // if (state.sorterByEndingSoon) {
+      //   return [
+      //     ...markets.filter(market => filterByisEndingSoon(market.expiresAt)),
+      //     ...orderBy(
+      //       markets.filter(market => !filterByisEndingSoon(market.expiresAt)),
+      //       [state.sorter.value],
+      //       [state.sorter.sortBy]
+      //     )
+      //   ];
+      // }
       return orderBy(markets, [state.sorter.value], [state.sorter.sortBy]);
     }
 


### PR DESCRIPTION
# [IFL - Change default sorting and filters in Markets list](https://app.shortcut.com/polkamarkets/story/808/ifl-change-default-sorting-and-filters-in-markets-list)

- Sort markets by "Expiration Date ASC" instead of our custom sorting algo
- By default, filter markets by "Open" and "Closed" state