### PR TITLE
[NO-STORY] Allow page overflow after transak closes

### DIFF
--- a/src/components/integrations/Transak/Transak.tsx
+++ b/src/components/integrations/Transak/Transak.tsx
@@ -147,12 +147,11 @@ function Transak() {
       transak.on(transak.ALL_EVENTS, data => {
         transakDispatch({ type: data.eventName });
       });
-
-      transak.on(transak.EVENTS.TRANSAK_WIDGET_CLOSE, _data => {
-        transak.close().then(() => {
-          document.documentElement.style.overflow = 'hidden';
-        });
-      });
+      transak.on(transak.EVENTS.TRANSAK_WIDGET_CLOSE, () =>
+        transak
+          .close()
+          .then(() => document.documentElement.style.removeProperty('overflow'))
+      );
     }
   }, [transak]);
 


### PR DESCRIPTION
After transak operations, the document element still has `overflow: hidden` on its styles. This PR fixes it.

## 💡 Functionality
<!-- Describe in details and by steps how could we accomplish the functionalities applied in this PR. Example below. -->
<!-- Remove functionality section if it has no items -->

### 1st Test
1. Open `Buy $ETH` or any operation which uses transak api;
2. After close it, inspect the document element node for having any styles;

## ⚡ Changelog
<!-- What and why would be added, changed or removed after that pull request. -->
<!-- Remove changelog section if it has no items -->

| _Unit_ | 🟢 Added | 🟡 Changed | 🔴 Removed |
| - | - | - | - |
|🟡`<Transak />`|  |Remove document element after transak operations |  |

## 🧪 Test Suite
- Navbar Actions
  - [x] Switch between light and dark mode across pages
  - [x] Network Switcher
  - [x] Wrong Network Modal
- Homepage Markets Navigation
  - [x] Filters
  - [x] Sorting
  - [x] Search
- Pages Content
  - [x] Homepage
  - [x] Create Market Page
  - [x] Market Page
  - [x] Portfolio
  - [x] Achievements
- Trading (**Optional** - only if PR involves related components or `polkamarkets-js`)
  - [ ] Slider + MAX button
  - [ ] Buy Outcome Shares
  - [ ] Sell Outcome Shares
  - [ ] Add Liquidity 
  - [ ] Remove Liquidity

### Footnotes
<!-- Remove footnotes subsection if it has no changelog and backlog items -->

> `useHook()` is related to React JS hooks, located on `src/hooks/` path;
> 
> `<Component />`/ `<Component [prop=value] />` is related to React JS components, located on `src/components/` path;
> 
> `module()` is related to modules located on `src/utils/` or anywhere else on the app that provides some usefull shared resource;
