### PR TITLE
[1116] `.` divider not working on liquidity/create market form

### DIFF
--- a/src/components/AmountInput/AmountInput.tsx
+++ b/src/components/AmountInput/AmountInput.tsx
@@ -104,7 +104,8 @@ export default function AmountInput({
           type="number"
           id={label}
           value={amount}
-          step=".00001"
+          lang="en"
+          step=".0001"
           min={0}
           max={max}
           onChange={handleChangeAmount}

--- a/src/components/AmountInput/AmountInput.tsx
+++ b/src/components/AmountInput/AmountInput.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect } from 'react';
 
-import { WalletIcon } from 'assets/icons';
+import { TokenIcon, WalletIcon } from 'assets/icons';
 
 import { Button } from '../Button';
+import Icon from '../Icon';
 import StepSlider from '../StepSlider';
 import Text from '../Text';
 
@@ -65,6 +66,8 @@ export default function AmountInput({
     setStepAmount(value);
   }
 
+  const { name, ticker, iconName } = currency;
+
   return (
     <div className="pm-c-amount-input">
       <div className="pm-c-amount-input__header">
@@ -120,7 +123,22 @@ export default function AmountInput({
           >
             Max
           </button>
-          {endAdornment}
+          {endAdornment || (
+            <div className="pm-c-amount-input__logo">
+              {iconName !== 'shares' ? (
+                <figure aria-label={name}>
+                  {iconName === 'Token' ? (
+                    <TokenIcon ticker={ticker} />
+                  ) : (
+                    <Icon name={iconName} />
+                  )}
+                </figure>
+              ) : null}
+              <Text as="span" scale="caption" fontWeight="bold">
+                {ticker}
+              </Text>
+            </div>
+          )}
         </div>
       </div>
       <StepSlider

--- a/src/components/AmountInput/AmountInput.tsx
+++ b/src/components/AmountInput/AmountInput.tsx
@@ -33,7 +33,7 @@ export default function AmountInput({
   disabled = false,
   endAdornment
 }: AmountInputProps) {
-  const [amount, setAmount] = useState(0);
+  const [amount, setAmount] = useState<number | undefined>(0);
   const [stepAmount, setStepAmount] = useState(0);
 
   useEffect(() => {
@@ -44,11 +44,13 @@ export default function AmountInput({
   }, [max]);
 
   function handleChangeAmount(event: React.ChangeEvent<HTMLInputElement>) {
-    const value = parseFloat(event.currentTarget.value);
+    const { value } = event.currentTarget;
 
-    setAmount(value);
-    setStepAmount(100 * ((value || 0) / max));
-    onChange(value || 0);
+    const newAmount = value ? parseFloat(value) : undefined;
+
+    setAmount(newAmount);
+    setStepAmount(100 * ((newAmount || 0) / max));
+    onChange(newAmount || 0);
   }
   function handleSetMaxAmount() {
     const roundedMax = round(max);

--- a/src/components/LiquidityForm/LiquidityFormInput.tsx
+++ b/src/components/LiquidityForm/LiquidityFormInput.tsx
@@ -85,7 +85,7 @@ function LiquidityFormInput() {
   function currentCurrency() {
     return transactionType === 'add'
       ? token
-      : { name: 'Shares', ticker: 'Shares' };
+      : { name: 'Shares', ticker: 'Shares', iconName: 'shares' };
   }
 
   function handleChangeAmount(liquidityAmount: number) {


### PR DESCRIPTION
# [`.` divider not working on liquidity/create market form](https://app.shortcut.com/polkamarkets/story/1116/divider-not-working-on-liquidity-create-market-form)

