### PR TITLE
[no-story] Hook Adjustments

### DIFF
--- a/src/ui/useTheme/useTheme.tsx
+++ b/src/ui/useTheme/useTheme.tsx
@@ -44,7 +44,11 @@ function handleChangeTheme(arg: ThemeProps['device']['mode']) {
   );
 }
 
-export function useTheme() {
+/**
+ * Returns the theme object and provide a callback for theme mode change.
+ * @returns {ThemeProps}
+ */
+export function useTheme(): ThemeProps {
   return useContext(ThemeContext);
 }
 export function isThemeDark(
@@ -53,7 +57,6 @@ export function isThemeDark(
   return mode === 'dark';
 }
 export default function ThemeProvider(props: ThemeProviderProps) {
-  // setting default theme to dark
   const [mode, setMode] = useLocalStorage<ThemeModes>(
     THEME_MODE_KEY,
     THEME_MODE_DEFAULT

--- a/src/ui/useUpdateEffect/useUpdateEffect.ts
+++ b/src/ui/useUpdateEffect/useUpdateEffect.ts
@@ -1,16 +1,18 @@
 import { useLayoutEffect, useRef } from 'react';
 
 /**
- * Fires the effect callback just after updates. Has the same signature as `useLayoutEffect`.
+ * Fires the effect callback just after updates.
+ * Has the same signature as `useLayoutEffect`, but with the dependency list required.
  */
 export default function useUpdateEffect(
-  ...args: Parameters<typeof useLayoutEffect>
+  effect: React.EffectCallback,
+  deps: React.DependencyList
 ) {
   const isMountPhase = useRef(true);
 
   useLayoutEffect(() => {
     if (isMountPhase.current) isMountPhase.current = false;
-    else args[0]();
+    else effect();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, args?.[1]);
+  }, deps);
 }

--- a/src/ui/useUpdateEffect/useUpdateEffect.ts
+++ b/src/ui/useUpdateEffect/useUpdateEffect.ts
@@ -1,14 +1,16 @@
 import { useLayoutEffect, useRef } from 'react';
 
+/**
+ * Fires the effect callback just after updates. Has the same signature as `useLayoutEffect`.
+ */
 export default function useUpdateEffect(
   ...args: Parameters<typeof useLayoutEffect>
 ) {
-  const didMount = useRef(true);
+  const isMountPhase = useRef(true);
 
   useLayoutEffect(() => {
-    if (didMount.current) {
-      didMount.current = false;
-    } else args[0]();
+    if (isMountPhase.current) isMountPhase.current = false;
+    else args[0]();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, args[1]);
+  }, args?.[1]);
 }


### PR DESCRIPTION
# [_Required: Replace with the Story Name_](https://app.shortcut.com/polkamarkets/story/)

_Required: PR description and not the its story self with the context of what was done before its opening! Fill down the references (1) below if necessary. It may help the reviewers find bugs and test the approach in the best way possible._

### References
<!-- Remove references subsection if it has no items -->

1. [Example](https://developer.mozilla.org/en-US/);

<img src="https://user-images.githubusercontent.com/16447765/188663770-80b5c7a5-6242-4142-89b0-67e50d8aa592.png" width="250" />
<!-- Replace this image with demo video or remove if it's not applied -->

## 💡 Functionality
<!-- Describe in details and by steps how could we accomplish the functionalities applied in this PR. Example below. -->
<!-- Remove functionality section if it has no items -->

### 1st Test
1. Do this;
2. Do that;

## ⚡ Changelog
<!-- What and why would be added, changed or removed after that pull request. -->
<!-- Remove changelog section if it has no items -->

| _Unit_ | 🟢 Added | 🟡 Changed | 🔴 Removed |
| - | - | - | - |
| 🟢/🟡/🔴 _The unity name..._ | _Good and short add-change description..._ | _Good and short change description..._ | _Good and short remove-change description..._ |

## 🐛 Backlog
<!-- Known bugs or missing units that could be merged without cause any damage, just to do not block the product development. -->
<!-- Remove backlog section if it has no items -->

| _Unit_ | Has story? | Description |
| - | - | - |
| _The unity name..._ | [_Replace with the Story Number_](https://app.shortcut.com/polkamarkets/story/)/🔴 | _Good and short of-why description..._ | 

### Footnotes
<!-- Remove footnotes subsection if it has no changelog and backlog items -->

> `useHook()` is related to React JS hooks, located on `src/hooks/` path;
> 
> `<Component />`/ `<Component [prop=value] />` is related to React JS components, located on `src/components/` path;
> 
> `module()` is related to modules located on `src/utils/` or anywhere else on the app that provides some usefull shared resource;
