### PR TITLE
[1151] My Positions Table - Wrong Alignment on Outcome Tags

### DIFF
--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -52,7 +52,7 @@ function Badge({
     >
       <div className="pm-c-badge__circle" />
       {label ? (
-        <Text className="pm-c-badge__label" as="label">
+        <Text className="pm-c-badge__label" as="span">
           {label}
         </Text>
       ) : null}

--- a/src/styles/base/_global.scss
+++ b/src/styles/base/_global.scss
@@ -1,6 +1,6 @@
 body {
   font-size: 1.6rem;
-  line-height: 1;
+  line-height: 1.5;
   background-color: var(--color-background-primary);
   font-family: 'Gilroy', sans-serif;
   -webkit-font-smoothing: antialiased;

--- a/src/styles/components/_badge.scss
+++ b/src/styles/components/_badge.scss
@@ -2,11 +2,11 @@
   height: 24px;
   border-radius: 12px;
   display: inline-flex;
+  align-items: center;
   gap: $badge-gap;
   color: var(--color-text-primary);
 
   &__circle {
-    align-self: center;
     height: $badge-circle-height;
     width: $badge-circle-width;
     border-radius: 50%;
@@ -18,6 +18,7 @@
   &__label {
     @extend .caption, .semibold;
     text-align: left;
+    line-height: unset !important;
   }
 
   @include themes($badge-themes) {


### PR DESCRIPTION
# [_Required: Replace with the Story Name_](https://app.shortcut.com/polkamarkets/story/)

_Required: PR description and not the its story self with the context of what was done before its opening! Fill down the references (1) below if necessary. It may help the reviewers find bugs and test the approach in the best way possible._

### References
<!-- Remove references subsection if it has no items -->

1. [Example](https://developer.mozilla.org/en-US/);

<img src="https://user-images.githubusercontent.com/16447765/188663770-80b5c7a5-6242-4142-89b0-67e50d8aa592.png" width="250" />
<!-- Replace this image with demo video or remove if it's not applied -->

## 💡 Functionality
<!-- Describe in details and by steps how could we accomplish the functionalities applied in this PR. Example below. -->
<!-- Remove functionality section if it has no items -->

### 1st Test
1. Do this;
2. Do that;

## ⚡ Changelog
<!-- What and why would be added, changed or removed after that pull request. -->
<!-- Remove changelog section if it has no items -->

| _Unit_ | 🟢 Added | 🟡 Changed | 🔴 Removed |
| - | - | - | - |
| 🟢/🟡/🔴 _The unity name..._ | _Good and short add-change description..._ | _Good and short change description..._ | _Good and short remove-change description..._ |

## 🐛 Backlog
<!-- Known bugs or missing units that could be merged without cause any damage, just to do not block the product development. -->
<!-- Remove backlog section if it has no items -->

| _Unit_ | Has story? | Description |
| - | - | - |
| _The unity name..._ | [_Replace with the Story Number_](https://app.shortcut.com/polkamarkets/story/)/🔴 | _Good and short of-why description..._ | 

### Footnotes
<!-- Remove footnotes subsection if it has no changelog and backlog items -->

> `useHook()` is related to React JS hooks, located on `src/hooks/` path;
> 
> `<Component />`/ `<Component [prop=value] />` is related to React JS components, located on `src/components/` path;
> 
> `module()` is related to modules located on `src/utils/` or anywhere else on the app that provides some usefull shared resource;
