### PR TITLE
[1423] Fantasy - Email login with wrong font color in dark mode

### DIFF
--- a/src/components/ProfileSigninEmail/ProfileSigninEmail.module.scss
+++ b/src/components/ProfileSigninEmail/ProfileSigninEmail.module.scss
@@ -1,21 +1,22 @@
 .root {
+  --border-color: var(--color-text-secondary);
   display: flex;
   align-items: center;
-  height: 40px;
   gap: 12px;
+  height: 40px;
   padding-left: 12px;
   padding-right: 12px;
-  border: 1px solid var(--color);
+  border: 1px solid var(--border-color);
   border-radius: 8px;
-  --color: var(--color-text-secondary);
+  color: var(--color-text-primary);
 
   &:focus-within {
-    --color: var(--color-main-primary);
+    --border-color: var(--color-main-primary);
   }
 }
 
 .disabled {
-  --color: var(--color-text-quinary);
+  --border-color: var(--color-text-quinary);
 }
 
 .input {


### PR DESCRIPTION
## 🗃 Story Description

<!-- Shortcut link example: [1423](https://app.shortcut.com/polkamarkets/story/1423/fantasy-email-login-with-wrong-font-color-in-dark-mode) -->
_Link to Shortcut card, if PR is part of a story._

## 🧪 Test Suite
- Navbar Actions
  - [x] Switch between light and dark mode across pages
  - [x] Network Switcher
  - [x] Wrong Network Modal
- Homepage Markets Navigation
  - [x] Filters
  - [x] Sorting
  - [x] Search
- Pages Content
  - [x] Homepage
  - [x] Create Market Page
  - [x] Market Page
  - [x] Portfolio
- Trading (**Optional** - only if PR involves related components or `polkamarkets-js`)
  - [ ] Slider + MAX button
  - [ ] Buy Outcome Shares
  - [ ] Sell Outcome Shares
  - [ ] Add Liquidity 
  - [ ] Remove Liquidity
 
  ## 📝 Footnotes
  _Noting to add._
