### PR TITLE
[1433] Fantasy - Optional Market Image (Style)

### DIFF
--- a/src/components/CreateMarketFormFund/MarketPreview/MarketPreview.tsx
+++ b/src/components/CreateMarketFormFund/MarketPreview/MarketPreview.tsx
@@ -39,7 +39,7 @@ function MarketPreview({ token }: MarketPreviewProps) {
         <div className={MarketPreviewClasses.bodyHeader}>
           {image.isUploaded ? (
             <Avatar
-              $radius="lg"
+              $radius="sm"
               $size="md"
               alt="Market"
               src={`https://polkamarkets.infura-ipfs.io/ipfs/${image.hash}`}

--- a/src/components/Market/Market.tsx
+++ b/src/components/Market/Market.tsx
@@ -49,7 +49,7 @@ function Market({ market }: MarketCardProps) {
       {!isNull(market.imageUrl) && (
         <MarketAvatar
           $size="md"
-          $radius="xs"
+          $radius="sm"
           imageUrl={market.imageUrl}
           verified={!theme.device.isDesktop && market.verified}
         />

--- a/src/components/Market/Market.tsx
+++ b/src/components/Market/Market.tsx
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 import { Link } from 'react-router-dom';
 
 import { features } from 'config';
+import { isNull } from 'lodash';
 import { Market as MarketInterface } from 'models/market';
 import { useTheme } from 'ui';
 
@@ -45,11 +46,13 @@ function Market({ market }: MarketCardProps) {
       to={`/markets/${market.slug}`}
       onClick={handleNavigation}
     >
-      <MarketAvatar
-        $size="md"
-        imageUrl={market.imageUrl}
-        verified={!theme.device.isDesktop && market.verified}
-      />
+      {!isNull(market.imageUrl) && (
+        <MarketAvatar
+          $size="md"
+          imageUrl={market.imageUrl}
+          verified={!theme.device.isDesktop && market.verified}
+        />
+      )}
       <div className="pm-c-market__body-details">
         <MarketCategory
           category={market.category}

--- a/src/components/Market/Market.tsx
+++ b/src/components/Market/Market.tsx
@@ -49,6 +49,7 @@ function Market({ market }: MarketCardProps) {
       {!isNull(market.imageUrl) && (
         <MarketAvatar
           $size="md"
+          $radius="xs"
           imageUrl={market.imageUrl}
           verified={!theme.device.isDesktop && market.verified}
         />

--- a/src/components/MarketAvatar/MarketAvatar.tsx
+++ b/src/components/MarketAvatar/MarketAvatar.tsx
@@ -8,8 +8,9 @@ import Logos from 'components/Logos';
 
 import marketAvatarClasses from './MarketAvatar.module.scss';
 
-type MarketAvatarProps = Pick<Market, 'imageUrl' | 'verified'> &
-  Pick<ImageProps, '$size'>;
+type MarketAvatarProps = Pick<Market, 'verified'> &
+  Pick<ImageProps, '$size'> &
+  Record<'imageUrl', string>;
 
 export default function MarketAvatar({
   imageUrl,

--- a/src/components/MarketAvatar/MarketAvatar.tsx
+++ b/src/components/MarketAvatar/MarketAvatar.tsx
@@ -9,17 +9,17 @@ import Logos from 'components/Logos';
 import marketAvatarClasses from './MarketAvatar.module.scss';
 
 type MarketAvatarProps = Pick<Market, 'verified'> &
-  Pick<ImageProps, '$size'> &
+  Pick<ImageProps, '$size' | '$radius'> &
   Record<'imageUrl', string>;
 
 export default function MarketAvatar({
   imageUrl,
-  $size,
-  verified
+  verified,
+  ...props
 }: MarketAvatarProps) {
   return (
     <div className={marketAvatarClasses.root}>
-      <Image $radius="lg" alt="Market" $size={$size} src={imageUrl}>
+      <Image alt="Market" src={imageUrl} {...props}>
         <Logos size="md" standard="mono" />
       </Image>
       {verified && (

--- a/src/components/PortfolioMarketTable/PortfolioMarketTable.module.scss
+++ b/src/components/PortfolioMarketTable/PortfolioMarketTable.module.scss
@@ -1,0 +1,10 @@
+.row {
+  &Market {
+    display: flex;
+    align-items: center;
+
+    &Avatar {
+      margin-right: 16px;
+    }
+  }
+}

--- a/src/components/PortfolioMarketTable/PortfolioMarketTable.tsx
+++ b/src/components/PortfolioMarketTable/PortfolioMarketTable.tsx
@@ -6,8 +6,10 @@ import { useHistory } from 'react-router-dom';
 import classnames from 'classnames';
 import { colorByOutcomeId } from 'helpers/color';
 import { roundNumber } from 'helpers/math';
+import { isNull } from 'lodash';
 import isEmpty from 'lodash/isEmpty';
 import { login, fetchAditionalData } from 'redux/ducks/polkamarkets';
+import { Avatar } from 'ui';
 
 import {
   ArrowDownIcon,
@@ -29,6 +31,7 @@ import Badge from '../Badge';
 import { ButtonLoading } from '../Button';
 import Pill from '../Pill';
 import Text from '../Text';
+import portfolioMarketTableClasses from './PortfolioMarketTable.module.scss';
 
 type MarketTableProps = {
   rows: any[];
@@ -165,20 +168,18 @@ const PortfolioMarketTable = ({
                     onClick={() => redirectTo(market.slug)}
                     style={{ cursor: 'pointer' }}
                   >
-                    <div
-                      style={{
-                        display: 'flex',
-                        gap: '1.6rem',
-                        alignItems: 'center'
-                      }}
-                    >
-                      <img
-                        src={market.imageUrl}
-                        alt={market.id}
-                        height={32}
-                        width={32}
-                        style={{ borderRadius: '50%' }}
-                      />
+                    <div className={portfolioMarketTableClasses.rowMarket}>
+                      {!isNull(market.imageUrl) && (
+                        <Avatar
+                          className={
+                            portfolioMarketTableClasses.rowMarketAvatar
+                          }
+                          src={market.imageUrl}
+                          alt={market.title}
+                          $size="xs"
+                          $radius="xs"
+                        />
+                      )}
                       {market.title}
                     </div>
                   </td>

--- a/src/components/Trade/TradePredictions.tsx
+++ b/src/components/Trade/TradePredictions.tsx
@@ -102,7 +102,7 @@ function TradePredictions({
                 <div className={styles.predictionTitleGroup}>
                   {withImages ? (
                     <Image
-                      $radius="lg"
+                      $radius="xs"
                       alt={outcome.title}
                       $size="xs"
                       src={outcome.imageUrl}

--- a/src/helpers/buildMarketColors.ts
+++ b/src/helpers/buildMarketColors.ts
@@ -1,5 +1,4 @@
 import type { Market } from 'models/market';
-import { getAverageColor } from 'ui';
 
 type Color = string;
 type OutcomeColors = Record<number, Color>;
@@ -12,6 +11,8 @@ export type MarketColorsByNetwork = Record<
 export default async function buildMarketColors(
   data: ReadonlyArray<Market>
 ): Promise<MarketColorsByNetwork> {
+  const { getAverageColor } = await import('ui');
+
   let marketColors: MarketColorsByNetwork = {};
 
   // eslint-disable-next-line no-restricted-syntax

--- a/src/models/market.ts
+++ b/src/models/market.ts
@@ -49,7 +49,7 @@ export interface Market {
   category: string;
   subcategory: string;
   resolutionSource?: string | null;
-  imageUrl: string;
+  imageUrl: string | null;
   bannerUrl: string;
   title: string;
   description: string;

--- a/src/pages/Leaderboard/Leaderboard.tsx
+++ b/src/pages/Leaderboard/Leaderboard.tsx
@@ -3,13 +3,14 @@ import { useLocation, useParams, matchPath } from 'react-router-dom';
 
 import cn from 'classnames';
 import { ui, pages } from 'config';
+import { isNull } from 'lodash';
 import {
   useGetLeaderboardByTimeframeQuery,
   useGetLeaderboardGroupBySlugQuery,
   useGetTournamentBySlugQuery,
   useJoinLeaderboardGroupMutation
 } from 'services/Polkamarkets';
-import { Container, useTheme } from 'ui';
+import { Container, Image, useTheme } from 'ui';
 
 import { CreateLeaderboardGroup, Link, Tabs } from 'components';
 import { ButtonLoading } from 'components/Button';
@@ -371,15 +372,14 @@ function Leaderboard() {
     <Container className="pm-p-leaderboard max-width-screen-xl">
       <div className="pm-p-leaderboard__header">
         <div className="flex-row gap-5 align-start">
-          {leaderboardImageUrl ? (
-            <img
-              className="pm-p-leaderboard__avatar"
+          {!isNull(leaderboardImageUrl) && (
+            <Image
+              $size="md"
+              $radius="sm"
               alt={leaderboardTitle}
               src={leaderboardImageUrl}
-              width={64}
-              height={64}
             />
-          ) : null}
+          )}
           <div className="flex-column gap-3">
             <div className="flex-row gap-5 align-center">
               <h1 className="heading semibold text-1">{leaderboardTitle}</h1>

--- a/src/pages/Leaderboard/LeaderboardMarkets.tsx
+++ b/src/pages/Leaderboard/LeaderboardMarkets.tsx
@@ -1,7 +1,7 @@
 import { Link } from 'react-router-dom';
 
 import cn from 'classnames';
-import isEmpty from 'lodash/isEmpty';
+import { isNull, isEmpty } from 'lodash';
 import { Tournament } from 'types/tournament';
 import { useTheme } from 'ui';
 
@@ -52,11 +52,13 @@ function LeaderboardMarkets({
           {data?.map(market => (
             <li key={market.slug}>
               <Link className={styles.market} to={`/markets/${market.slug}`}>
-                <img
-                  className={styles.marketImage}
-                  src={market.imageUrl}
-                  alt={market.title}
-                />
+                {!isNull(market.imageUrl) && (
+                  <img
+                    className={styles.marketImage}
+                    src={market.imageUrl}
+                    alt={market.title}
+                  />
+                )}
                 <p
                   className={cn(
                     styles.marketTitle,

--- a/src/pages/Leaderboard/LeaderboardMarkets.tsx
+++ b/src/pages/Leaderboard/LeaderboardMarkets.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import cn from 'classnames';
 import { isNull, isEmpty } from 'lodash';
 import { Tournament } from 'types/tournament';
-import { useTheme } from 'ui';
+import { Image, useTheme } from 'ui';
 
 import { AlertMini } from 'components';
 
@@ -53,8 +53,9 @@ function LeaderboardMarkets({
             <li key={market.slug}>
               <Link className={styles.market} to={`/markets/${market.slug}`}>
                 {!isNull(market.imageUrl) && (
-                  <img
-                    className={styles.marketImage}
+                  <Image
+                    $size="x2s"
+                    $radius="xs"
                     src={market.imageUrl}
                     alt={market.title}
                   />

--- a/src/pages/Market/MarketHead.tsx
+++ b/src/pages/Market/MarketHead.tsx
@@ -47,6 +47,7 @@ export default function MarketHead() {
       >
         {!isNull(market.imageUrl) && (
           <MarketAvatar
+            $radius={theme.device.isDesktop ? 'sm' : 'xs'}
             $size={theme.device.isDesktop ? 'lg' : 'md'}
             imageUrl={market.imageUrl}
             verified={!theme.device.isDesktop && market.verified}

--- a/src/pages/Market/MarketHead.tsx
+++ b/src/pages/Market/MarketHead.tsx
@@ -1,6 +1,7 @@
 import { Fragment } from 'react';
 
 import getMarketColors from 'helpers/getMarketColors';
+import { isNull } from 'lodash';
 import { Container, Hero, useTheme } from 'ui';
 
 import { MarketAvatar, MarketCategory, Text } from 'components';
@@ -23,8 +24,10 @@ function MarketHeadWrapper(
   return (
     <Hero
       className={marketClasses.hero}
-      $image={market.imageUrl}
       $backdrop={marketColors.market}
+      {...(!isNull(market.imageUrl) && {
+        $image: market.imageUrl
+      })}
       {...props}
     />
   );
@@ -42,11 +45,13 @@ export default function MarketHead() {
         $enableGutters={!theme.device.isDesktop}
         className={marketClasses.heroInfo}
       >
-        <MarketAvatar
-          $size={theme.device.isDesktop ? 'lg' : 'md'}
-          imageUrl={market.imageUrl}
-          verified={!theme.device.isDesktop && market.verified}
-        />
+        {!isNull(market.imageUrl) && (
+          <MarketAvatar
+            $size={theme.device.isDesktop ? 'lg' : 'md'}
+            imageUrl={market.imageUrl}
+            verified={!theme.device.isDesktop && market.verified}
+          />
+        )}
         <div>
           <MarketCategory
             category={market.category}

--- a/src/pages/Market/MarketHead.tsx
+++ b/src/pages/Market/MarketHead.tsx
@@ -47,7 +47,7 @@ export default function MarketHead() {
       >
         {!isNull(market.imageUrl) && (
           <MarketAvatar
-            $radius={theme.device.isDesktop ? 'sm' : 'xs'}
+            $radius={theme.device.isDesktop ? 'md' : 'sm'}
             $size={theme.device.isDesktop ? 'lg' : 'md'}
             imageUrl={market.imageUrl}
             verified={!theme.device.isDesktop && market.verified}

--- a/src/pages/Market/MarketShares.tsx
+++ b/src/pages/Market/MarketShares.tsx
@@ -115,7 +115,7 @@ function MarketShares({ onSellSelected }: MarketSharesProps) {
                   {outcome.imageUrl ? (
                     <Image
                       className={styles.rootItemTitleGroupImage}
-                      $radius="lg"
+                      $radius="xs"
                       alt={outcome.title}
                       $size="x2s"
                       src={outcome.imageUrl}

--- a/src/pages/Tournaments/TournamentsList.module.scss
+++ b/src/pages/Tournaments/TournamentsList.module.scss
@@ -6,26 +6,6 @@
 
   padding: var(--size-16);
 
-  &Avatar {
-    display: flex;
-    flex-shrink: 0;
-    overflow: hidden;
-
-    width: 40px;
-    height: 40px;
-    background-color: var(--color-tournament-avatar-background);
-    border-radius: 20px;
-  }
-
-  &Image {
-    width: 100%;
-    height: auto;
-  }
-
-  &Initials {
-    margin: auto;
-  }
-
   &Description {
     display: -webkit-box;
     overflow: hidden;

--- a/src/pages/Tournaments/TournamentsList.module.scss
+++ b/src/pages/Tournaments/TournamentsList.module.scss
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  gap: var(--size-8);
+  gap: var(--size-16);
 
   padding: var(--size-16);
 

--- a/src/pages/Tournaments/TournamentsList.tsx
+++ b/src/pages/Tournaments/TournamentsList.tsx
@@ -1,7 +1,6 @@
 import { Link } from 'react-router-dom';
 
 import cn from 'classnames';
-import { isNull } from 'lodash';
 import isEmpty from 'lodash/isEmpty';
 import { useGetTournamentsQuery } from 'services/Polkamarkets';
 import { Avatar } from 'ui';
@@ -40,14 +39,12 @@ function TournamentsList() {
               'bg-3': index % 2 === 0
             })}
           >
-            {!isNull(tournament.imageUrl) && (
-              <Avatar
-                src={tournament.imageUrl}
-                alt={tournament.title}
-                $size="xs"
-                $radius="xs"
-              />
-            )}
+            <Avatar
+              src={tournament.imageUrl || ''}
+              alt={tournament.title}
+              $size="xs"
+              $radius="xs"
+            />
             <div>
               <span className="body semibold text-2 text-1-on-hover">
                 {tournament.title}

--- a/src/pages/Tournaments/TournamentsList.tsx
+++ b/src/pages/Tournaments/TournamentsList.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom';
 
 import cn from 'classnames';
+import { isNull } from 'lodash';
 import isEmpty from 'lodash/isEmpty';
 import { useGetTournamentsQuery } from 'services/Polkamarkets';
 import { Avatar } from 'ui';
@@ -39,12 +40,14 @@ function TournamentsList() {
               'bg-3': index % 2 === 0
             })}
           >
-            <Avatar
-              src={tournament.imageUrl || ''}
-              alt={tournament.title}
-              $size="xs"
-              $radius="xs"
-            />
+            {!isNull(tournament.imageUrl) && (
+              <Avatar
+                src={tournament.imageUrl}
+                alt={tournament.title}
+                $size="xs"
+                $radius="xs"
+              />
+            )}
             <div>
               <span className="body semibold text-2 text-1-on-hover">
                 {tournament.title}

--- a/src/pages/Tournaments/TournamentsList.tsx
+++ b/src/pages/Tournaments/TournamentsList.tsx
@@ -1,8 +1,10 @@
 import { Link } from 'react-router-dom';
 
 import cn from 'classnames';
+import { isNull } from 'lodash';
 import isEmpty from 'lodash/isEmpty';
 import { useGetTournamentsQuery } from 'services/Polkamarkets';
+import { Avatar } from 'ui';
 
 import { AlertMini } from 'components';
 
@@ -38,19 +40,14 @@ function TournamentsList() {
               'bg-3': index % 2 === 0
             })}
           >
-            <div className={styles.itemAvatar}>
-              {tournament.imageUrl ? (
-                <img
-                  src={tournament.imageUrl}
-                  alt="Tournament Avatar"
-                  className={styles.itemAmage}
-                />
-              ) : (
-                <p className={cn('body text-3 bold', styles.itemInitials)}>
-                  {tournament.title.match(/\w/)}
-                </p>
-              )}
-            </div>
+            {!isNull(tournament.imageUrl) && (
+              <Avatar
+                src={tournament.imageUrl}
+                alt={tournament.title}
+                $size="xs"
+                $radius="xs"
+              />
+            )}
             <div>
               <span className="body semibold text-2 text-1-on-hover">
                 {tournament.title}

--- a/src/redux/ducks/market.ts
+++ b/src/redux/ducks/market.ts
@@ -50,7 +50,7 @@ const initialState: MarketInitialState = {
     category: '',
     subcategory: '',
     resolutionSource: null,
-    imageUrl: '',
+    imageUrl: null,
     bannerUrl: '',
     title: '',
     description: '',

--- a/src/styles/pages/_leaderboard.scss
+++ b/src/styles/pages/_leaderboard.scss
@@ -11,14 +11,6 @@
     width: 100%;
     margin-bottom: var(--size-12);
   }
-
-  &__avatar {
-    object-fit: cover;
-    border-radius: 50%;
-
-    height: var(--size-64);
-    height: var(--size-64);
-  }
 }
 
 .pm-c-leaderboard-table {

--- a/src/ui/getAverageColor/getAverageColor.ts
+++ b/src/ui/getAverageColor/getAverageColor.ts
@@ -16,7 +16,9 @@ function getImage(src: string, options: Record<'width' | 'height', number>) {
  * @param {string} src Source link image.
  * @returns {Promise<string>} RGB color string-like `RRR GGG BBB`
  */
-export default async function getAverageColor(src: string): Promise<string> {
+export default async function getAverageColor(
+  src: string | null
+): Promise<string> {
   const context = document.createElement('canvas').getContext?.('2d', {
     willReadFrequently: true
   });


### PR DESCRIPTION
## 🗃 Story Description

<!-- Shortcut link example: [Fantasy - Optional Market Image (Style)](https://app.shortcut.com/polkamarkets/story/1433/fantasy-optional-market-image-style) -->
_Link to Shortcut card, if PR is part of a story._

## 🧪 Test Suite
- Navbar Actions
  - [x] Switch between light and dark mode across pages
  - [x] Network Switcher
  - [x] Wrong Network Modal
- Homepage Markets Navigation
  - [x] Filters
  - [x] Sorting
  - [x] Search
- Pages Content
  - [x] Homepage
  - [x] Create Market Page
  - [x] Market Page
  - [x] Portfolio
- Trading (**Optional** - only if PR involves related components or `polkamarkets-js`)
  - [x] Slider + MAX button
  - [x] Buy Outcome Shares
  - [x] Sell Outcome Shares
  - [x] Add Liquidity 
  - [x] Remove Liquidity
 
  ## 📝 Footnotes
  _Noting to add._
