### PR TITLE
[1440] Fantasy - Optional Market Image (Logic)

### DIFF
--- a/src/components/CreateMarketForm/CreateMarketForm.tsx
+++ b/src/components/CreateMarketForm/CreateMarketForm.tsx
@@ -3,7 +3,7 @@ import { useHistory } from 'react-router-dom';
 
 import * as realitioLib from '@reality.eth/reality-eth-lib/formatters/question';
 import { features } from 'config';
-import { Formik, Form } from 'formik';
+import { Formik, Form, getIn } from 'formik';
 import { fetchAditionalData, login } from 'redux/ducks/polkamarkets';
 import * as marketService from 'services/Polkamarkets/market';
 import { Token } from 'types/token';
@@ -125,6 +125,19 @@ function CreateMarketForm() {
 
   const currentValidationSchema = validationSchema[currentStep];
 
+  const isRequiredField = useCallback(
+    name => {
+      const schemaDescription = currentValidationSchema.describe();
+      const accessor = name.split('.').join('.fields.');
+      const field = getIn(schemaDescription.fields, accessor);
+
+      if (!field) return false;
+
+      return !field.optional;
+    },
+    [currentValidationSchema]
+  );
+
   return (
     <>
       <ToastNotification id="createMarket" duration={10000}>
@@ -165,6 +178,7 @@ function CreateMarketForm() {
             <Steps
               current={currentStep}
               currentStepFields={Object.keys(currentValidationSchema.fields)}
+              isRequiredField={isRequiredField}
               steps={[
                 {
                   id: 'details',

--- a/src/components/CreateMarketForm/CreateMarketForm.tsx
+++ b/src/components/CreateMarketForm/CreateMarketForm.tsx
@@ -89,7 +89,8 @@ function CreateMarketForm() {
     const image =
       images.length > 0
         ? `${values.image.hash}${realitioLib.delimiter()}${images.join(',')}`
-        : values.image.hash;
+        : // TODO: what's the format for !values.image.hash (no image)?
+          values.image.hash;
 
     const response = await polkamarketsService.createMarket(
       values.question,

--- a/src/components/CreateMarketForm/CreateMarketForm.tsx
+++ b/src/components/CreateMarketForm/CreateMarketForm.tsx
@@ -86,11 +86,9 @@ function CreateMarketForm() {
     }`;
 
     // images format: "market image hash␟outcome image hash,outcome image hash,..."
-    const image =
-      images.length > 0
-        ? `${values.image.hash}${realitioLib.delimiter()}${images.join(',')}`
-        : // TODO: what's the format for !values.image.hash (no image)?
-          values.image.hash;
+    const image = `${values.image.hash || ''}${
+      images.length > 0 ? `${realitioLib.delimiter()}${images.join(',')}` : ''
+    }`;
 
     const response = await polkamarketsService.createMarket(
       values.question,

--- a/src/components/CreateMarketForm/CreateMarketForm.tsx
+++ b/src/components/CreateMarketForm/CreateMarketForm.tsx
@@ -86,7 +86,7 @@ function CreateMarketForm() {
     }`;
 
     // images format: "market image hash␟outcome image hash,outcome image hash,..."
-    const image = `${values.image.hash || ''}${
+    const image = `${values.image.hash}${
       images.length > 0 ? `${realitioLib.delimiter()}${images.join(',')}` : ''
     }`;
 

--- a/src/components/CreateMarketForm/CreateMarketForm.util.ts
+++ b/src/components/CreateMarketForm/CreateMarketForm.util.ts
@@ -70,7 +70,9 @@ const validationSchema = [
       )
       .required('Closing date is required.'),
     image: Yup.object().shape({
-      hash: Yup.string().required('Image is required.')
+      hash: features.fantasy.enabled
+        ? Yup.string()
+        : Yup.string().required('Image is required.')
     })
   }),
   Yup.object().shape({

--- a/src/components/CreateMarketFormDetails/CreateMarketFormDetails.tsx
+++ b/src/components/CreateMarketFormDetails/CreateMarketFormDetails.tsx
@@ -1,10 +1,9 @@
 import { useMemo } from 'react';
 
+import ui from 'config/ui';
 import { useField } from 'formik';
 
 import Feature from 'components/Feature';
-
-import { useFilters } from 'hooks';
 
 import {
   Input,
@@ -16,7 +15,6 @@ import {
 import CreateMarketFormDetailsClasses from './CreateMarketFormDetails.module.scss';
 
 function CreateMarketFormDetails() {
-  const { filters } = useFilters();
   const [field] = useField('image');
 
   const uploadedImageURL = field.value.isUploaded
@@ -25,11 +23,11 @@ function CreateMarketFormDetails() {
 
   const categories = useMemo(
     () =>
-      filters.dropdowns.categories.options.map(category => ({
-        name: category.label,
-        value: category.value
+      ui.filters.categories.options.map(category => ({
+        name: category,
+        value: category
       })),
-    [filters.dropdowns.categories.options]
+    []
   );
 
   return (

--- a/src/components/ImageCropper/ImageCropper.tsx
+++ b/src/components/ImageCropper/ImageCropper.tsx
@@ -44,7 +44,7 @@ function ImageCroppper({ image, onCrop, onCancel }: ImageCropperProps) {
           crop={crop}
           zoom={zoom}
           aspect={1}
-          cropShape="round"
+          cropShape="rect"
           onCropChange={setCrop}
           onCropComplete={onCropComplete}
           onZoomChange={setZoom}

--- a/src/components/Steps/Steps.tsx
+++ b/src/components/Steps/Steps.tsx
@@ -15,9 +15,16 @@ type StepsProps = {
   currentStepFields: string[];
   steps: Step[];
   onChange: (step: number) => void;
+  isRequiredField: (field: string) => boolean;
 };
 
-function Steps({ current, currentStepFields, steps, onChange }: StepsProps) {
+function Steps({
+  current,
+  currentStepFields,
+  steps,
+  onChange,
+  isRequiredField
+}: StepsProps) {
   const { isValid, touched, isSubmitting } = useFormikContext();
   const { network } = useNetwork();
 
@@ -38,7 +45,8 @@ function Steps({ current, currentStepFields, steps, onChange }: StepsProps) {
   }
 
   const isCurrentStepValid =
-    currentStepFields.every(field => touched[field]) && isValid;
+    currentStepFields.filter(isRequiredField).every(field => touched[field]) &&
+    isValid;
 
   return (
     <div className={StepsClasses.root}>

--- a/src/config/ui.ts
+++ b/src/config/ui.ts
@@ -20,6 +20,15 @@ const providers = [
   'Email'
 ] as const;
 
+const categories = [
+  'Society',
+  'Economy/Finance',
+  'Politics',
+  'Entertainment/Arts',
+  'Sports',
+  'Other'
+];
+
 export type Providers = typeof providers[number];
 
 const ui = {
@@ -76,7 +85,7 @@ const ui = {
     },
     categories: {
       enabled: !isTrue(environment.UI_FILTERS_CATEGORIES_DISABLED),
-      options: environment.UI_FILTERS_CATEGORIES?.split(',')
+      options: environment.UI_FILTERS_CATEGORIES?.split(',') || categories
     },
     tokens: ['USDT', 'USDC', 'DAI', 'MATIC', 'GLMR', 'MOVR'],
     tournaments: {

--- a/src/contexts/filters/filters.util.ts
+++ b/src/contexts/filters/filters.util.ts
@@ -63,33 +63,6 @@ const defaultDateRangeOptions: Option[] = [
   }
 ];
 
-const defaultCategoriesOptions: Option[] = [
-  {
-    label: 'Society',
-    value: 'Society'
-  },
-  {
-    label: 'Economy/Finance',
-    value: 'Economy/Finance'
-  },
-  {
-    label: 'Politics',
-    value: 'Politics'
-  },
-  {
-    label: 'Entertainment/Arts',
-    value: 'Entertainment/Arts'
-  },
-  {
-    label: 'Sports',
-    value: 'Sports'
-  },
-  {
-    label: 'Other',
-    value: 'Other'
-  }
-];
-
 const categoriesOptionsFromEnvironment = ui.filters.categories.options?.map(
   category => ({
     label: category,
@@ -171,7 +144,7 @@ const filters: Filters = {
     },
     categories: {
       title: 'Category',
-      options: categoriesOptionsFromEnvironment || defaultCategoriesOptions,
+      options: categoriesOptionsFromEnvironment,
       multiple: true,
       enabled: ui.filters.categories.enabled
     },


### PR DESCRIPTION
## 🗃 Story Description

<!-- Shortcut link example: [Fantasy - Optional Market Image (Logic)](https://app.shortcut.com/polkamarkets/story/1440/fantasy-optional-market-image-logic) -->
_Link to Shortcut card, if PR is part of a story._

## 🧪 Test Suite
- Navbar Actions
  - [x] Switch between light and dark mode across pages
  - [x] Network Switcher
  - [x] Wrong Network Modal
- Homepage Markets Navigation
  - [x] Filters
  - [x] Sorting
  - [x] Search
- Pages Content
  - [x] Homepage
  - [x] Create Market Page
  - [x] Market Page
  - [x] Portfolio
- Trading (**Optional** - only if PR involves related components or `polkamarkets-js`)
  - [ ] Slider + MAX button
  - [ ] Buy Outcome Shares
  - [ ] Sell Outcome Shares
  - [ ] Add Liquidity 
  - [ ] Remove Liquidity
 
  ## 📝 Footnotes
  _Noting to add._
