### PR TITLE
[1459] Fantasy - disable theme switcher

### DIFF
--- a/src/components/Header/HeaderActions.tsx
+++ b/src/components/Header/HeaderActions.tsx
@@ -123,7 +123,7 @@ export default function HeaderActions() {
             <HeaderActionComponent isLoggedIn={isLoggedIn} />
           )}
         </HeaderActionsGroupComponent>
-        <ThemeSelector />
+        {!features.fantasy.enabled && <ThemeSelector />}
         {ui.layout.header.helpUrl && (
           <a
             role="button"

--- a/src/ui/useTheme/useTheme.tsx
+++ b/src/ui/useTheme/useTheme.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext, useMemo } from 'react';
 
-import { environment } from 'config';
+import { environment, features } from 'config';
 import useMedia from 'ui/useMedia';
 import useUpdateEffect from 'ui/useUpdateEffect';
 
@@ -85,6 +85,7 @@ export default function ThemeProvider(props: ThemeProviderProps) {
     () => ({
       device: {
         mode: (() => {
+          if (features.fantasy.enabled) return 'dark';
           if (mode === THEME_MODES.system) {
             if (isDark) return 'dark';
             return 'light';
@@ -113,6 +114,9 @@ export default function ThemeProvider(props: ThemeProviderProps) {
 
     return () => window.clearTimeout(timer);
   }, [value.device.mode]);
+
+  if (features.fantasy.enabled && typeof window !== 'undefined')
+    window.localStorage.removeItem(THEME_MODE_KEY);
 
   return <ThemeContext.Provider value={value} {...props} />;
 }


### PR DESCRIPTION
## 🗃 Story Description

<!-- Shortcut link example: [1459](https://app.shortcut.com/polkamarkets/story/1459/fantasy-disable-theme-switcher) -->
_Link to Shortcut card, if PR is part of a story._

## 🧪 Test Suite
- Navbar Actions
  - [x] Switch between light and dark mode across pages
  - [x] Network Switcher
  - [x] Wrong Network Modal
- Homepage Markets Navigation
  - [x] Filters
  - [x] Sorting
  - [x] Search
- Pages Content
  - [x] Homepage
  - [x] Create Market Page
  - [x] Market Page
  - [x] Portfolio
- Trading (**Optional** - only if PR involves related components or `polkamarkets-js`)
  - [ ] Slider + MAX button
  - [ ] Buy Outcome Shares
  - [ ] Sell Outcome Shares
  - [ ] Add Liquidity 
  - [ ] Remove Liquidity
 
  ## 📝 Footnotes
  _Noting to add._
