### PR TITLE
feat(Trade): only allow buying 1 outcome

### DIFF
--- a/src/components/ModalContent/ModalContent.module.scss
+++ b/src/components/ModalContent/ModalContent.module.scss
@@ -5,6 +5,6 @@
   border-radius: 0.4rem;
   box-shadow: 0rem 0.4rem 2.4rem var(--color-shadow);
 
-  max-height: 100vh;
+  max-height: 100dvh;
   overflow-y: auto;
 }


### PR DESCRIPTION
## 🗃 Story Description

<!-- Shortcut link example: [xxxx](https://app.shortcut.com/polkamarkets/story/xxxx/) -->
_Link to Shortcut card, if PR is part of a story._

## 🧪 Test Suite
- Navbar Actions
  - [ ] Switch between light and dark mode across pages
  - [ ] Network Switcher
  - [ ] Wrong Network Modal
- Homepage Markets Navigation
  - [ ] Filters
  - [ ] Sorting
  - [ ] Search
- Pages Content
  - [ ] Homepage
  - [ ] Create Market Page
  - [ ] Market Page
  - [ ] Portfolio
- Trading (**Optional** - only if PR involves related components or `polkamarkets-js`)
  - [ ] Slider + MAX button
  - [ ] Buy Outcome Shares
  - [ ] Sell Outcome Shares
  - [ ] Add Liquidity 
  - [ ] Remove Liquidity
 
  ## 📝 Footnotes
  _Noting to add._
