### PR TITLE
[1468] Hide trade carrossel buttons with 2 outcomes

### DIFF
--- a/src/components/Trade/Trade.module.scss
+++ b/src/components/Trade/Trade.module.scss
@@ -258,6 +258,10 @@
     scrollbar-width: none;
   }
 
+  &NonScroll {
+    justify-content: center;
+  }
+
   &Item {
     margin: 0 var(--size-8);
 

--- a/src/components/Trade/TradePredictionsWithImages.tsx
+++ b/src/components/Trade/TradePredictionsWithImages.tsx
@@ -96,11 +96,15 @@ function TradePredictionsWithImages({
 
   return (
     <ScrollMenu
-      wrapperClassName={styles.predictionsWithImageWrapper}
-      scrollContainerClassName={styles.predictionsWithImageScroll}
+      wrapperClassName={multiple ? styles.predictionsWithImageWrapper : ''}
+      scrollContainerClassName={
+        multiple
+          ? styles.predictionsWithImageScroll
+          : styles.predictionsWithImageNonScroll
+      }
       itemClassName={styles.predictionsWithImageItem}
-      LeftArrow={LeftArrow}
-      RightArrow={RightArrow}
+      LeftArrow={multiple ? LeftArrow : undefined}
+      RightArrow={multiple ? RightArrow : undefined}
       onWheel={onWheel}
     >
       {predictions.map((prediction, index) => (


### PR DESCRIPTION
## 🗃 Story Description

<!-- Shortcut link example: [Hide trade carrossel buttons with 2 outcomes](https://app.shortcut.com/polkamarkets/story/1468/hide-trade-carrossel-buttons-with-2-outcomes) -->
_Link to Shortcut card, if PR is part of a story._

## 🧪 Test Suite
- Navbar Actions
  - [ ] Switch between light and dark mode across pages
  - [ ] Network Switcher
  - [ ] Wrong Network Modal
- Homepage Markets Navigation
  - [ ] Filters
  - [ ] Sorting
  - [ ] Search
- Pages Content
  - [ ] Homepage
  - [ ] Create Market Page
  - [ ] Market Page
  - [ ] Portfolio
- Trading (**Optional** - only if PR involves related components or `polkamarkets-js`)
  - [ ] Slider + MAX button
  - [ ] Buy Outcome Shares
  - [ ] Sell Outcome Shares
  - [ ] Add Liquidity 
  - [ ] Remove Liquidity
 
  ## 📝 Footnotes
  _Noting to add._
