### PR TITLE
feat(MarketChart): display probabilities on fantasy mode

### DIFF
--- a/src/components/LineChart/options.ts
+++ b/src/components/LineChart/options.ts
@@ -1,3 +1,4 @@
+import features from 'config/features';
 import { categoricalColorsInHex } from 'helpers/color';
 
 function generateCustomOptions(
@@ -27,7 +28,10 @@ function generateCustomOptions(
       },
       y: {
         show: true,
-        formatter: value => `${parseFloat(value).toFixed(3)} ${ticker}`
+        formatter: value =>
+          features.fantasy.enabled
+            ? `${(parseFloat(value) * 100).toFixed(1)}%`
+            : `${parseFloat(value).toFixed(3)} ${ticker}`
       }
     },
     legend: {
@@ -103,7 +107,9 @@ function generateCustomOptions(
       labels: {
         show: true,
         formatter(value) {
-          return `${value}`;
+          return features.fantasy.enabled
+            ? `${(value * 100).toFixed(0)}%`
+            : `${value}`;
         },
         offsetX: -15,
         style: {

--- a/src/pages/Market/MarketChart.tsx
+++ b/src/pages/Market/MarketChart.tsx
@@ -32,14 +32,18 @@ function MarketOverview() {
     <>
       <div className="market-chart__header">
         <div>
-          <Text scale="tiny-uppercase" color="gray" fontWeight="semibold">
-            {highOutcome.title}
+          <Text
+            scale="body"
+            fontWeight="semibold"
+            className="market-chart__view-title"
+          >
+            {highOutcome.title.toUpperCase()}
           </Text>
           <Text
-            as="h3"
-            scale="heading-large"
+            color="light-gray"
+            scale="heading"
             fontWeight="semibold"
-            className="market-chart__view-title notranslate"
+            className="notranslate"
           >
             {features.fantasy.enabled ? (
               <>{roundNumber(highOutcome.price * 100, 3)}%</>

--- a/src/pages/Market/MarketChart.tsx
+++ b/src/pages/Market/MarketChart.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react';
 import TradingViewWidget, { Themes } from 'react-tradingview-widget';
 
+import { features } from 'config';
+import { roundNumber } from 'helpers/math';
 import sortOutcomes from 'helpers/sortOutcomes';
 import { useTheme } from 'ui';
 
@@ -39,7 +41,13 @@ function MarketOverview() {
             fontWeight="semibold"
             className="market-chart__view-title notranslate"
           >
-            {highOutcome.price} {ticker}
+            {features.fantasy.enabled ? (
+              <>{roundNumber(highOutcome.price * 100, 3)}%</>
+            ) : (
+              <>
+                {highOutcome.price} {ticker}
+              </>
+            )}
           </Text>
           <Text
             as="span"
@@ -48,8 +56,14 @@ function MarketOverview() {
             fontWeight="semibold"
             className="notranslate"
           >
-            {highOutcome.pricesDiff.value} {ticker} (
-            {highOutcome.pricesDiff.pct})
+            {features.fantasy.enabled ? (
+              <>{highOutcome.pricesDiff.pct}</>
+            ) : (
+              <>
+                {highOutcome.pricesDiff.value} {ticker} (
+                {highOutcome.pricesDiff.pct})
+              </>
+            )}
           </Text>{' '}
           <Text as="span" scale="tiny" color="gray" fontWeight="semibold">
             Since Market Creation


### PR DESCRIPTION
## 🗃 Story Description

<!-- Shortcut link example: [xxxx](https://app.shortcut.com/polkamarkets/story/xxxx/) -->
_Link to Shortcut card, if PR is part of a story._

## 🧪 Test Suite
- Navbar Actions
  - [ ] Switch between light and dark mode across pages
  - [ ] Network Switcher
  - [ ] Wrong Network Modal
- Homepage Markets Navigation
  - [ ] Filters
  - [ ] Sorting
  - [ ] Search
- Pages Content
  - [ ] Homepage
  - [ ] Create Market Page
  - [ ] Market Page
  - [ ] Portfolio
- Trading (**Optional** - only if PR involves related components or `polkamarkets-js`)
  - [ ] Slider + MAX button
  - [ ] Buy Outcome Shares
  - [ ] Sell Outcome Shares
  - [ ] Add Liquidity 
  - [ ] Remove Liquidity
 
  ## 📝 Footnotes
  _Noting to add._
