### PR TITLE
[ENG-183] “Show More” in multiple outcomes is not useful

### DIFF
--- a/src/components/MarketList/MarketList.tsx
+++ b/src/components/MarketList/MarketList.tsx
@@ -7,6 +7,7 @@ import type {
 import { Virtuoso as ReactVirtuoso } from 'react-virtuoso';
 
 import cn from 'classnames';
+import { features } from 'config';
 import { AnimatePresence, motion } from 'framer-motion';
 import type { Market } from 'models/market';
 import { useRect, useTheme } from 'ui';
@@ -15,7 +16,7 @@ import { InfoIcon } from 'assets/icons';
 
 import PredictionCard from 'components/PredictionCard';
 
-import { useMarkets } from 'hooks';
+import { useAppSelector, useMarkets } from 'hooks';
 
 import { Button } from '../Button';
 import Text from '../Text';
@@ -27,11 +28,15 @@ type VirtuosoProps = Omit<
 >;
 
 function Virtuoso({ data }: VirtuosoProps) {
+  const isLoggedIn = useAppSelector(state => state.polkamarkets.isLoggedIn);
   const theme = useTheme();
   const [back, backRect] = useRect();
+  const BACK_HEIGHT = `${backRect.height}px`;
   const HEIGHT = theme.device.isDesktop
-    ? `${backRect.height}px`
-    : `calc(${backRect.height}px + var(--header-y))`;
+    ? BACK_HEIGHT
+    : `calc(${BACK_HEIGHT} ${
+        !features.fantasy.enabled || isLoggedIn ? '+ var(--header-y)' : ''
+      })`;
   const virtuoso = useRef<VirtuosoHandle>(null);
   const [renderBack, setRenderBack] = useState(false);
   const handleItemContent = useCallback(

--- a/src/components/Trade/TradePredictions.tsx
+++ b/src/components/Trade/TradePredictions.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState, MouseEvent } from 'react';
+import { useCallback, useMemo, MouseEvent } from 'react';
 import { Virtuoso } from 'react-virtuoso';
 
 import cn from 'classnames';
@@ -19,7 +19,6 @@ type TradePredictionsProps = {
   onPredictionSelected?: () => void;
 };
 
-const DEFAULT_VISIBLE_PREDICTIONS = 3;
 
 function TradePredictions({
   view,
@@ -27,11 +26,6 @@ function TradePredictions({
   onPredictionSelected
 }: TradePredictionsProps) {
   const dispatch = useAppDispatch();
-  const [visiblePredictions, setVisiblePredictions] = useState(
-    DEFAULT_VISIBLE_PREDICTIONS
-  );
-  const hasVisiblePredictions =
-    visiblePredictions !== DEFAULT_VISIBLE_PREDICTIONS;
 
   const { id, outcomes, networkId } = useAppSelector(
     state => state.market.market
@@ -64,12 +58,9 @@ function TradePredictions({
   const multiple = predictions.length > 2;
   const withImages = predictions.every(outcome => !!outcome.imageUrl);
 
-  const on = multiple ? predictions.slice(0, visiblePredictions) : predictions;
-  const off = multiple ? predictions.slice(visiblePredictions) : [];
-
   const listHeight = Math.min(
     Math.ceil(window.innerHeight * (view === 'modal' ? 0.25 : 0.35)),
-    on.length * (size === 'md' ? 49 : 71)
+    predictions.length * (size === 'md' ? 60 : 82)
   );
 
   if (view === 'default' || (view === 'modal' && !withImages)) {
@@ -77,10 +68,9 @@ function TradePredictions({
       <div>
         <Virtuoso
           style={{
-            height: !hasVisiblePredictions ? listHeight : window.innerHeight
+            height: listHeight
           }}
-          useWindowScroll={hasVisiblePredictions}
-          data={on}
+          data={predictions}
           itemContent={(index, outcome) => (
             <button
               type="button"
@@ -127,17 +117,6 @@ function TradePredictions({
             </button>
           )}
         />
-        {predictions.length > 3 ? (
-          <button
-            type="button"
-            className={styles.predictionsShowMore}
-            onClick={() =>
-              setVisiblePredictions(off.length > 0 ? predictions.length : 3)
-            }
-          >
-            {off.length > 0 ? `Show More (${off.length})` : 'Show Less'}
-          </button>
-        ) : null}
       </div>
     );
   }

--- a/src/components/Trade/TradePredictions.tsx
+++ b/src/components/Trade/TradePredictions.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useMemo, useState, MouseEvent } from 'react';
+import { Virtuoso } from 'react-virtuoso';
 
 import cn from 'classnames';
 import { roundNumber } from 'helpers/math';
@@ -8,7 +9,6 @@ import { Image } from 'ui';
 
 import { useAppDispatch, useAppSelector } from 'hooks';
 
-import VirtualizedList from '../VirtualizedList';
 import styles from './Trade.module.scss';
 import { View } from './Trade.types';
 import TradePredictionsWithImages from './TradePredictionsWithImages';
@@ -19,13 +19,19 @@ type TradePredictionsProps = {
   onPredictionSelected?: () => void;
 };
 
+const DEFAULT_VISIBLE_PREDICTIONS = 3;
+
 function TradePredictions({
   view,
   size = 'md',
   onPredictionSelected
 }: TradePredictionsProps) {
   const dispatch = useAppDispatch();
-  const [visiblePredictions, setVisiblePredictions] = useState(3);
+  const [visiblePredictions, setVisiblePredictions] = useState(
+    DEFAULT_VISIBLE_PREDICTIONS
+  );
+  const hasVisiblePredictions =
+    visiblePredictions !== DEFAULT_VISIBLE_PREDICTIONS;
 
   const { id, outcomes, networkId } = useAppSelector(
     state => state.market.market
@@ -69,8 +75,11 @@ function TradePredictions({
   if (view === 'default' || (view === 'modal' && !withImages)) {
     return (
       <div>
-        <VirtualizedList
-          height={listHeight}
+        <Virtuoso
+          style={{
+            height: !hasVisiblePredictions ? listHeight : window.innerHeight
+          }}
+          useWindowScroll={hasVisiblePredictions}
           data={on}
           itemContent={(index, outcome) => (
             <button

--- a/src/pages/Market/Market.module.scss
+++ b/src/pages/Market/Market.module.scss
@@ -122,7 +122,7 @@
   flex-direction: column;
   gap: var(--size-12);
 
-  margin-bottom: 56px;
+  margin-bottom: 24px;
 
   &Title {
     font-size: 1.2rem;


### PR DESCRIPTION
## 🗃 Story Description

<!-- Shortcut link example: [xxxx](https://app.shortcut.com/polkamarkets/story/xxxx/) -->
_Link to Shortcut card, if PR is part of a story._

## 🧪 Test Suite
- Navbar Actions
  - [x] Switch between light and dark mode across pages
  - [x] Network Switcher
  - [x] Wrong Network Modal
- Homepage Markets Navigation
  - [x] Filters
  - [X] Sorting
  - [x] Search
- Pages Content
  - [x] Homepage
  - [x] Create Market Page
  - [x] Market Page
  - [x] Portfolio
- Trading (**Optional** - only if PR involves related components or `polkamarkets-js`)
  - [x] Slider + MAX button
  - [x] Buy Outcome Shares
  - [x] Sell Outcome Shares
  - [x] Add Liquidity 
  - [x] Remove Liquidity
 
  ## 📝 Footnotes
  _Noting to add._
