### PR TITLE
[ENG-212] Keep the suggested prediction option visible once selected

### DIFF
--- a/src/components/TradeForm/TradeFormInput.tsx
+++ b/src/components/TradeForm/TradeFormInput.tsx
@@ -290,6 +290,9 @@ function TradeFormInput() {
                 <button
                   key={button}
                   type="button"
+                  className={cn('pm-c-amount-input__action', {
+                    'pm-c-amount-input__action--active': button === amount
+                  })}
                   onClick={() => handleSetAmount(button)}
                   disabled={isWrongNetwork || isLoadingBalance}
                 >
@@ -304,6 +307,9 @@ function TradeFormInput() {
                 <button
                   key={step}
                   type="button"
+                  className={cn('pm-c-amount-input__action', {
+                    'pm-c-amount-input__action--active': step === amount
+                  })}
                   onClick={() =>
                     handleSetAmount(roundDown(max() * (step / 100)))
                   }

--- a/src/styles/components/_amount-input.scss
+++ b/src/styles/components/_amount-input.scss
@@ -86,36 +86,38 @@
     &__actions {
       display: flex;
 
-      button {
-        display: inline-flex;
-        align-items: center;
-
-        cursor: pointer;
-        touch-action: manipulation;
-        appearance: none;
-        outline: none;
-        border: none;
-
-        margin: $amount-input-action-margin-y $amount-input-action-margin-x;
-        padding: $amount-input-action-button-padding-y
-          $amount-input-action-button-padding-x;
-        background-color: themed('amount-input-action-button-background-color');
-
-        @extend .tiny-uppercase, .bold;
-        color: themed('amount-input-action-button-color');
-
-        border-radius: $amount-input-action-button-border-radius;
-        transition: $amount-input-action-button-transitions;
-
-        &:hover {
-          background-color: themed(
-            'amount-input-action-button-background-color-hover'
-          );
-        }
-      }
-
       :disabled {
         pointer-events: none;
+      }
+    }
+
+    &__action {
+      display: inline-flex;
+      align-items: center;
+
+      cursor: pointer;
+      touch-action: manipulation;
+      appearance: none;
+      outline: none;
+      border: none;
+
+      margin: $amount-input-action-margin-y $amount-input-action-margin-x;
+      padding: $amount-input-action-button-padding-y
+        $amount-input-action-button-padding-x;
+      background-color: themed('amount-input-action-button-background-color');
+
+      @extend .tiny-uppercase, .bold;
+      color: themed('amount-input-action-button-color');
+
+      border-radius: $amount-input-action-button-border-radius;
+      transition: $amount-input-action-button-transitions;
+
+      &:hover,
+      &:focus,
+      &--active {
+        background-color: themed(
+          'amount-input-action-button-background-color-hover'
+        );
       }
     }
 


### PR DESCRIPTION
## 🗃 Story Description

[ENG-212](https://linear.app/polkamarkets-labs/issue/ENG-212/keep-the-suggested-prediction-option-visible-once-selected)

## 🧪 Test Suite
- Navbar Actions
  - [ ] Switch between light and dark mode across pages
  - [ ] Network Switcher
  - [ ] Wrong Network Modal
- Homepage Markets Navigation
  - [ ] Filters
  - [ ] Sorting
  - [ ] Search
- Pages Content
  - [ ] Homepage
  - [ ] Create Market Page
  - [ ] Market Page
  - [ ] Portfolio
- Trading (**Optional** - only if PR involves related components or `polkamarkets-js`)
  - [x] Slider + MAX button
  - [x] Buy Outcome Shares
  - [x] Sell Outcome Shares
  - [x] Add Liquidity 
  - [x] Remove Liquidity
 
  ## 📝 Footnotes
  _Noting to add._
