### PR TITLE
[ENG-230] Unwrap text on prediction status (mobile)

### DIFF
--- a/src/pages/Market/MarketShares.module.scss
+++ b/src/pages/Market/MarketShares.module.scss
@@ -12,11 +12,13 @@
   border-radius: var(--size-4);
 
   &Item {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    align-items: center;
-    gap: var(--size-24);
+    @media (min-width: 768px) {
+      display: flex;
+      flex-direction: row;
+      justify-content: space-between;
+      align-items: center;
+      gap: var(--size-24);
+    }
 
     &TitleGroup {
       display: inline-flex;
@@ -36,6 +38,10 @@
       line-height: 1.6;
       font-weight: 500;
       color: var(--color-market-shares-description);
+
+      @media (max-width: 767px) {
+        margin-bottom: 16px;
+      }
 
       strong {
         color: var(--color-market-shares-description--bold);

--- a/src/pages/Market/MarketShares.module.scss
+++ b/src/pages/Market/MarketShares.module.scss
@@ -12,13 +12,11 @@
   border-radius: var(--size-4);
 
   &Item {
-    @media (min-width: 768px) {
-      display: flex;
-      flex-direction: row;
-      justify-content: space-between;
-      align-items: center;
-      gap: var(--size-24);
-    }
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    gap: var(--size-24);
 
     &TitleGroup {
       display: inline-flex;
@@ -39,23 +37,9 @@
       font-weight: 500;
       color: var(--color-market-shares-description);
 
-      @media (max-width: 767px) {
-        margin-bottom: 16px;
-      }
-
       strong {
         color: var(--color-market-shares-description--bold);
       }
     }
   }
-}
-
-.loading {
-  padding: var(--size-16);
-}
-
-.spinner {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
 }

--- a/src/pages/Market/MarketShares.module.scss
+++ b/src/pages/Market/MarketShares.module.scss
@@ -12,11 +12,13 @@
   border-radius: var(--size-4);
 
   &Item {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    align-items: center;
-    gap: var(--size-24);
+    @media (min-width: 768px) {
+      display: flex;
+      flex-direction: row;
+      justify-content: space-between;
+      align-items: center;
+      gap: var(--size-24);
+    }
 
     &TitleGroup {
       display: inline-flex;
@@ -37,9 +39,23 @@
       font-weight: 500;
       color: var(--color-market-shares-description);
 
+      @media (max-width: 767px) {
+        margin-bottom: 16px;
+      }
+
       strong {
         color: var(--color-market-shares-description--bold);
       }
     }
   }
+}
+
+.loading {
+  padding: var(--size-16);
+}
+
+.spinner {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
 }

--- a/src/pages/Market/MarketShares.module.scss
+++ b/src/pages/Market/MarketShares.module.scss
@@ -24,7 +24,6 @@
       align-items: center;
       gap: var(--size-4);
 
-      padding: 0 var(--size-4);
       vertical-align: bottom;
 
       &Image {
@@ -37,14 +36,6 @@
       line-height: 1.6;
       font-weight: 500;
       color: var(--color-market-shares-description);
-
-      text-overflow: ellipsis;
-      overflow: hidden;
-
-      display: -webkit-box;
-      -webkit-line-clamp: 1;
-      -webkit-box-orient: vertical;
-      word-break: break-all;
 
       strong {
         color: var(--color-market-shares-description--bold);

--- a/src/pages/Market/MarketShares.tsx
+++ b/src/pages/Market/MarketShares.tsx
@@ -1,13 +1,12 @@
 /* eslint-disable no-nested-ternary */
 import { useCallback, useMemo } from 'react';
 
-import classNames from 'classnames';
 import { roundNumber } from 'helpers/math';
 import isEmpty from 'lodash/isEmpty';
 import { changeTradeType, selectOutcome } from 'redux/ducks/trade';
-import { Image, Spinner, useTheme } from 'ui';
+import { Image } from 'ui';
 
-import { Button, Text } from 'components';
+import { Button } from 'components';
 
 import { useAppDispatch, useAppSelector, useLanguage, useNetwork } from 'hooks';
 
@@ -30,7 +29,6 @@ function MarketShares({ onSellSelected }: MarketSharesProps) {
   const { portfolio: isLoadingPortfolio } = useAppSelector(
     state => state.polkamarkets.isLoading
   );
-  const theme = useTheme();
 
   const language = useLanguage();
 
@@ -84,128 +82,104 @@ function MarketShares({ onSellSelected }: MarketSharesProps) {
 
   const isWrongNetwork = network.id !== networkId.toString();
 
-  const isLoading = isWrongNetwork || isEmpty(outcomesWithShares);
+  if (isWrongNetwork || isEmpty(outcomesWithShares)) return null;
 
   return (
-    <ul
-      className={classNames(styles.root, {
-        [styles.loading]: isLoading
-      })}
-    >
-      {isLoading ? (
-        <div className={styles.spinner}>
-          <Spinner $size="md" />
-          <Text
-            as="span"
-            scale="caption"
-            fontWeight="medium"
-            color="lighter-gray"
-          >
-            Loading shares...
-          </Text>
-        </div>
-      ) : (
-        outcomesWithShares.map(outcome => (
-          <li key={outcome.id} className={styles.rootItem}>
-            <p className={`${styles.rootItemDescription} notranslate`}>
-              {language === 'tr' ? (
-                <>
-                  Şu anda <strong>{`${roundNumber(outcome.shares, 3)}`}</strong>{' '}
-                  adet{' '}
-                  <div className={styles.rootItemTitleGroup}>
-                    {outcome.imageUrl ? (
-                      <Image
-                        className={styles.rootItemTitleGroupImage}
-                        $radius="lg"
-                        alt={outcome.title}
-                        $size="x2s"
-                        src={outcome.imageUrl}
-                      />
-                    ) : null}
-                    <strong>{outcome.title}</strong>
-                  </div>{' '}
-                  hissesine sahipsiniz ve bunun değeri{' '}
-                  <strong>
-                    {outcome.value.toFixed(3)} {token.symbol}
-                  </strong>{' '}
-                  denk geliyor
-                </>
-              ) : language === 'pt' ? (
-                <>
-                  Tens{' '}
-                  <strong>
-                    {outcome.value.toFixed(1)} {token.symbol}{' '}
-                  </strong>
-                  de{' '}
-                  <div className={styles.rootItemTitleGroup}>
-                    {outcome.imageUrl ? (
-                      <Image
-                        className={styles.rootItemTitleGroupImage}
-                        $radius="xs"
-                        alt={outcome.title}
-                        $size="x2s"
-                        src={outcome.imageUrl}
-                      />
-                    ) : null}
-                    <strong>{outcome.title}</strong>
-                  </div>{' '}
-                  com um desempenho de{' '}
-                  <strong>
-                    {outcome.value > outcome.buyValue ? '+' : ''}
-                    {(outcome.value - outcome.buyValue).toFixed(1)}{' '}
-                    {token.symbol}{' '}
-                  </strong>
-                  ({outcome.value > outcome.buyValue ? '+' : ''}
-                  {(
-                    ((outcome.value - outcome.buyValue) / outcome.buyValue) *
-                    100
-                  ).toFixed(1)}
-                  %)
-                </>
-              ) : (
-                <>
-                  You hold{' '}
-                  <strong>
-                    {outcome.value.toFixed(1)} {token.symbol}{' '}
-                  </strong>
-                  of{' '}
-                  <div className={styles.rootItemTitleGroup}>
-                    {outcome.imageUrl ? (
-                      <Image
-                        className={styles.rootItemTitleGroupImage}
-                        $radius="xs"
-                        alt={outcome.title}
-                        $size="x2s"
-                        src={outcome.imageUrl}
-                      />
-                    ) : null}
-                    <strong>{outcome.title}</strong>
-                  </div>{' '}
-                  performing{' '}
-                  <strong>
-                    {outcome.value > outcome.buyValue ? '+' : ''}
-                    {(outcome.value - outcome.buyValue).toFixed(1)}{' '}
-                    {token.symbol}{' '}
-                  </strong>
-                  ({outcome.value > outcome.buyValue ? '+' : ''}
-                  {(
-                    ((outcome.value - outcome.buyValue) / outcome.buyValue) *
-                    100
-                  ).toFixed(1)}
-                  %)
-                </>
-              )}
-            </p>
-            <Button
-              size="sm"
-              fullwidth={!theme.device.isTablet}
-              onClick={() => handleSell(outcome.id)}
-            >
-              Sell Position
-            </Button>
-          </li>
-        ))
-      )}
+    <ul className={styles.root}>
+      {outcomesWithShares.map(outcome => (
+        <li key={outcome.id} className={styles.rootItem}>
+          <p className={`${styles.rootItemDescription} notranslate`}>
+            {language === 'tr' ? (
+              <>
+                Şu anda <strong>{`${roundNumber(outcome.shares, 3)}`}</strong>{' '}
+                adet{' '}
+                <div className={styles.rootItemTitleGroup}>
+                  {outcome.imageUrl ? (
+                    <Image
+                      className={styles.rootItemTitleGroupImage}
+                      $radius="lg"
+                      alt={outcome.title}
+                      $size="x2s"
+                      src={outcome.imageUrl}
+                    />
+                  ) : null}
+                  <strong>{outcome.title}</strong>
+                </div>{' '}
+                hissesine sahipsiniz ve bunun değeri{' '}
+                <strong>
+                  {outcome.value.toFixed(3)} {token.symbol}
+                </strong>{' '}
+                denk geliyor
+              </>
+            ) : language === 'pt' ? (
+              <>
+                Tens{' '}
+                <strong>
+                  {outcome.value.toFixed(1)} {token.symbol}{' '}
+                </strong>
+                de{' '}
+                <div className={styles.rootItemTitleGroup}>
+                  {outcome.imageUrl ? (
+                    <Image
+                      className={styles.rootItemTitleGroupImage}
+                      $radius="xs"
+                      alt={outcome.title}
+                      $size="x2s"
+                      src={outcome.imageUrl}
+                    />
+                  ) : null}
+                  <strong>{outcome.title}</strong>
+                </div>{' '}
+                com um desempenho de{' '}
+                <strong>
+                  {outcome.value > outcome.buyValue ? '+' : ''}
+                  {(outcome.value - outcome.buyValue).toFixed(1)} {token.symbol}{' '}
+                </strong>
+                ({outcome.value > outcome.buyValue ? '+' : ''}
+                {(
+                  ((outcome.value - outcome.buyValue) / outcome.buyValue) *
+                  100
+                ).toFixed(1)}
+                %)
+              </>
+            ) : (
+              <>
+                You hold{' '}
+                <strong>
+                  {outcome.value.toFixed(1)} {token.symbol}{' '}
+                </strong>
+                of{' '}
+                <div className={styles.rootItemTitleGroup}>
+                  {outcome.imageUrl ? (
+                    <Image
+                      className={styles.rootItemTitleGroupImage}
+                      $radius="xs"
+                      alt={outcome.title}
+                      $size="x2s"
+                      src={outcome.imageUrl}
+                    />
+                  ) : null}
+                  <strong>{outcome.title}</strong>
+                </div>{' '}
+                performing{' '}
+                <strong>
+                  {outcome.value > outcome.buyValue ? '+' : ''}
+                  {(outcome.value - outcome.buyValue).toFixed(1)} {token.symbol}{' '}
+                </strong>
+                ({outcome.value > outcome.buyValue ? '+' : ''}
+                {(
+                  ((outcome.value - outcome.buyValue) / outcome.buyValue) *
+                  100
+                ).toFixed(1)}
+                %)
+              </>
+            )}
+          </p>
+          <Button size="sm" onClick={() => handleSell(outcome.id)}>
+            Sell Position
+          </Button>
+        </li>
+      ))}
     </ul>
   );
 }

--- a/src/pages/Market/MarketShares.tsx
+++ b/src/pages/Market/MarketShares.tsx
@@ -92,7 +92,7 @@ function MarketShares({ onSellSelected }: MarketSharesProps) {
             {language === 'tr' ? (
               <>
                 Şu anda <strong>{`${roundNumber(outcome.shares, 3)}`}</strong>{' '}
-                adet
+                adet{' '}
                 <div className={styles.rootItemTitleGroup}>
                   {outcome.imageUrl ? (
                     <Image
@@ -104,7 +104,7 @@ function MarketShares({ onSellSelected }: MarketSharesProps) {
                     />
                   ) : null}
                   <strong>{outcome.title}</strong>
-                </div>
+                </div>{' '}
                 hissesine sahipsiniz ve bunun değeri{' '}
                 <strong>
                   {outcome.value.toFixed(3)} {token.symbol}
@@ -117,7 +117,7 @@ function MarketShares({ onSellSelected }: MarketSharesProps) {
                 <strong>
                   {outcome.value.toFixed(1)} {token.symbol}{' '}
                 </strong>
-                de
+                de{' '}
                 <div className={styles.rootItemTitleGroup}>
                   {outcome.imageUrl ? (
                     <Image
@@ -129,7 +129,7 @@ function MarketShares({ onSellSelected }: MarketSharesProps) {
                     />
                   ) : null}
                   <strong>{outcome.title}</strong>
-                </div>
+                </div>{' '}
                 com um desempenho de{' '}
                 <strong>
                   {outcome.value > outcome.buyValue ? '+' : ''}
@@ -148,7 +148,7 @@ function MarketShares({ onSellSelected }: MarketSharesProps) {
                 <strong>
                   {outcome.value.toFixed(1)} {token.symbol}{' '}
                 </strong>
-                of
+                of{' '}
                 <div className={styles.rootItemTitleGroup}>
                   {outcome.imageUrl ? (
                     <Image
@@ -160,7 +160,7 @@ function MarketShares({ onSellSelected }: MarketSharesProps) {
                     />
                   ) : null}
                   <strong>{outcome.title}</strong>
-                </div>
+                </div>{' '}
                 performing{' '}
                 <strong>
                   {outcome.value > outcome.buyValue ? '+' : ''}

--- a/src/pages/Market/MarketShares.tsx
+++ b/src/pages/Market/MarketShares.tsx
@@ -4,7 +4,7 @@ import { useCallback, useMemo } from 'react';
 import { roundNumber } from 'helpers/math';
 import isEmpty from 'lodash/isEmpty';
 import { changeTradeType, selectOutcome } from 'redux/ducks/trade';
-import { Image } from 'ui';
+import { Image, useTheme } from 'ui';
 
 import { Button } from 'components';
 
@@ -29,6 +29,7 @@ function MarketShares({ onSellSelected }: MarketSharesProps) {
   const { portfolio: isLoadingPortfolio } = useAppSelector(
     state => state.polkamarkets.isLoading
   );
+  const theme = useTheme();
 
   const language = useLanguage();
 
@@ -175,7 +176,11 @@ function MarketShares({ onSellSelected }: MarketSharesProps) {
               </>
             )}
           </p>
-          <Button size="sm" onClick={() => handleSell(outcome.id)}>
+          <Button
+            size="sm"
+            fullwidth={!theme.device.isTablet}
+            onClick={() => handleSell(outcome.id)}
+          >
             Sell Position
           </Button>
         </li>

--- a/src/pages/Market/MarketShares.tsx
+++ b/src/pages/Market/MarketShares.tsx
@@ -1,12 +1,13 @@
 /* eslint-disable no-nested-ternary */
 import { useCallback, useMemo } from 'react';
 
+import classNames from 'classnames';
 import { roundNumber } from 'helpers/math';
 import isEmpty from 'lodash/isEmpty';
 import { changeTradeType, selectOutcome } from 'redux/ducks/trade';
-import { Image } from 'ui';
+import { Image, Spinner, useTheme } from 'ui';
 
-import { Button } from 'components';
+import { Button, Text } from 'components';
 
 import { useAppDispatch, useAppSelector, useLanguage, useNetwork } from 'hooks';
 
@@ -29,6 +30,7 @@ function MarketShares({ onSellSelected }: MarketSharesProps) {
   const { portfolio: isLoadingPortfolio } = useAppSelector(
     state => state.polkamarkets.isLoading
   );
+  const theme = useTheme();
 
   const language = useLanguage();
 
@@ -82,104 +84,128 @@ function MarketShares({ onSellSelected }: MarketSharesProps) {
 
   const isWrongNetwork = network.id !== networkId.toString();
 
-  if (isWrongNetwork || isEmpty(outcomesWithShares)) return null;
+  const isLoading = isWrongNetwork || isEmpty(outcomesWithShares);
 
   return (
-    <ul className={styles.root}>
-      {outcomesWithShares.map(outcome => (
-        <li key={outcome.id} className={styles.rootItem}>
-          <p className={`${styles.rootItemDescription} notranslate`}>
-            {language === 'tr' ? (
-              <>
-                Şu anda <strong>{`${roundNumber(outcome.shares, 3)}`}</strong>{' '}
-                adet{' '}
-                <div className={styles.rootItemTitleGroup}>
-                  {outcome.imageUrl ? (
-                    <Image
-                      className={styles.rootItemTitleGroupImage}
-                      $radius="lg"
-                      alt={outcome.title}
-                      $size="x2s"
-                      src={outcome.imageUrl}
-                    />
-                  ) : null}
-                  <strong>{outcome.title}</strong>
-                </div>{' '}
-                hissesine sahipsiniz ve bunun değeri{' '}
-                <strong>
-                  {outcome.value.toFixed(3)} {token.symbol}
-                </strong>{' '}
-                denk geliyor
-              </>
-            ) : language === 'pt' ? (
-              <>
-                Tens{' '}
-                <strong>
-                  {outcome.value.toFixed(1)} {token.symbol}{' '}
-                </strong>
-                de{' '}
-                <div className={styles.rootItemTitleGroup}>
-                  {outcome.imageUrl ? (
-                    <Image
-                      className={styles.rootItemTitleGroupImage}
-                      $radius="xs"
-                      alt={outcome.title}
-                      $size="x2s"
-                      src={outcome.imageUrl}
-                    />
-                  ) : null}
-                  <strong>{outcome.title}</strong>
-                </div>{' '}
-                com um desempenho de{' '}
-                <strong>
-                  {outcome.value > outcome.buyValue ? '+' : ''}
-                  {(outcome.value - outcome.buyValue).toFixed(1)} {token.symbol}{' '}
-                </strong>
-                ({outcome.value > outcome.buyValue ? '+' : ''}
-                {(
-                  ((outcome.value - outcome.buyValue) / outcome.buyValue) *
-                  100
-                ).toFixed(1)}
-                %)
-              </>
-            ) : (
-              <>
-                You hold{' '}
-                <strong>
-                  {outcome.value.toFixed(1)} {token.symbol}{' '}
-                </strong>
-                of{' '}
-                <div className={styles.rootItemTitleGroup}>
-                  {outcome.imageUrl ? (
-                    <Image
-                      className={styles.rootItemTitleGroupImage}
-                      $radius="xs"
-                      alt={outcome.title}
-                      $size="x2s"
-                      src={outcome.imageUrl}
-                    />
-                  ) : null}
-                  <strong>{outcome.title}</strong>
-                </div>{' '}
-                performing{' '}
-                <strong>
-                  {outcome.value > outcome.buyValue ? '+' : ''}
-                  {(outcome.value - outcome.buyValue).toFixed(1)} {token.symbol}{' '}
-                </strong>
-                ({outcome.value > outcome.buyValue ? '+' : ''}
-                {(
-                  ((outcome.value - outcome.buyValue) / outcome.buyValue) *
-                  100
-                ).toFixed(1)}
-                %)
-              </>
-            )}
-          </p>
-          <Button size="sm" onClick={() => handleSell(outcome.id)}>
-            Sell Position
-          </Button>
-        </li>
-      ))}
+    <ul
+      className={classNames(styles.root, {
+        [styles.loading]: isLoading
+      })}
+    >
+      {isLoading ? (
+        <div className={styles.spinner}>
+          <Spinner $size="md" />
+          <Text
+            as="span"
+            scale="caption"
+            fontWeight="medium"
+            color="lighter-gray"
+          >
+            Loading shares...
+          </Text>
+        </div>
+      ) : (
+        outcomesWithShares.map(outcome => (
+          <li key={outcome.id} className={styles.rootItem}>
+            <p className={`${styles.rootItemDescription} notranslate`}>
+              {language === 'tr' ? (
+                <>
+                  Şu anda <strong>{`${roundNumber(outcome.shares, 3)}`}</strong>{' '}
+                  adet{' '}
+                  <div className={styles.rootItemTitleGroup}>
+                    {outcome.imageUrl ? (
+                      <Image
+                        className={styles.rootItemTitleGroupImage}
+                        $radius="lg"
+                        alt={outcome.title}
+                        $size="x2s"
+                        src={outcome.imageUrl}
+                      />
+                    ) : null}
+                    <strong>{outcome.title}</strong>
+                  </div>{' '}
+                  hissesine sahipsiniz ve bunun değeri{' '}
+                  <strong>
+                    {outcome.value.toFixed(3)} {token.symbol}
+                  </strong>{' '}
+                  denk geliyor
+                </>
+              ) : language === 'pt' ? (
+                <>
+                  Tens{' '}
+                  <strong>
+                    {outcome.value.toFixed(1)} {token.symbol}{' '}
+                  </strong>
+                  de{' '}
+                  <div className={styles.rootItemTitleGroup}>
+                    {outcome.imageUrl ? (
+                      <Image
+                        className={styles.rootItemTitleGroupImage}
+                        $radius="xs"
+                        alt={outcome.title}
+                        $size="x2s"
+                        src={outcome.imageUrl}
+                      />
+                    ) : null}
+                    <strong>{outcome.title}</strong>
+                  </div>{' '}
+                  com um desempenho de{' '}
+                  <strong>
+                    {outcome.value > outcome.buyValue ? '+' : ''}
+                    {(outcome.value - outcome.buyValue).toFixed(1)}{' '}
+                    {token.symbol}{' '}
+                  </strong>
+                  ({outcome.value > outcome.buyValue ? '+' : ''}
+                  {(
+                    ((outcome.value - outcome.buyValue) / outcome.buyValue) *
+                    100
+                  ).toFixed(1)}
+                  %)
+                </>
+              ) : (
+                <>
+                  You hold{' '}
+                  <strong>
+                    {outcome.value.toFixed(1)} {token.symbol}{' '}
+                  </strong>
+                  of{' '}
+                  <div className={styles.rootItemTitleGroup}>
+                    {outcome.imageUrl ? (
+                      <Image
+                        className={styles.rootItemTitleGroupImage}
+                        $radius="xs"
+                        alt={outcome.title}
+                        $size="x2s"
+                        src={outcome.imageUrl}
+                      />
+                    ) : null}
+                    <strong>{outcome.title}</strong>
+                  </div>{' '}
+                  performing{' '}
+                  <strong>
+                    {outcome.value > outcome.buyValue ? '+' : ''}
+                    {(outcome.value - outcome.buyValue).toFixed(1)}{' '}
+                    {token.symbol}{' '}
+                  </strong>
+                  ({outcome.value > outcome.buyValue ? '+' : ''}
+                  {(
+                    ((outcome.value - outcome.buyValue) / outcome.buyValue) *
+                    100
+                  ).toFixed(1)}
+                  %)
+                </>
+              )}
+            </p>
+            <Button
+              size="sm"
+              fullwidth={!theme.device.isTablet}
+              onClick={() => handleSell(outcome.id)}
+            >
+              Sell Position
+            </Button>
+          </li>
+        ))
+      )}
     </ul>
   );
 }


### PR DESCRIPTION
## 🗃 Story Description

[ENG-230](https://linear.app/polkamarkets-labs/issue/ENG-230/unwrap-text-on-prediction-status-mobile)

## 🧪 Test Suite
- Navbar Actions
  - [ ] Switch between light and dark mode across pages
  - [ ] Network Switcher
  - [ ] Wrong Network Modal
- Homepage Markets Navigation
  - [ ] Filters
  - [ ] Sorting
  - [ ] Search
- Pages Content
  - [ ] Homepage
  - [ ] Create Market Page
  - [ ] Market Page
  - [ ] Portfolio
- Trading (**Optional** - only if PR involves related components or `polkamarkets-js`)
  - [ ] Slider + MAX button
  - [ ] Buy Outcome Shares
  - [ ] Sell Outcome Shares
  - [ ] Add Liquidity 
  - [ ] Remove Liquidity
 
  ## 📝 Footnotes
  _Noting to add._
