### PR TITLE
[ENG-232] Prediction Modal: Change highlighted outcome when selling a prediction

### DIFF
--- a/src/components/Market/MarketOutcomes.tsx
+++ b/src/components/Market/MarketOutcomes.tsx
@@ -73,9 +73,7 @@ export default function MarketOutcomes({
   const setOutcome = useCallback(
     async (outcomeId: string) => {
       const { marketSelected } = await import('redux/ducks/market');
-      const { changeTradeType, selectOutcome } = await import(
-        'redux/ducks/trade'
-      );
+      const { selectOutcome } = await import('redux/ducks/trade');
       const hasPredictedOutcome =
         !!predictedOutcome && features.fantasy.enabled;
 
@@ -87,8 +85,6 @@ export default function MarketOutcomes({
           hasPredictedOutcome ? predictedOutcome : outcomeId
         )
       );
-
-      if (hasPredictedOutcome) dispatch(changeTradeType('sell'));
     },
     [dispatch, market, predictedOutcome]
   );

--- a/src/components/Market/MarketOutcomes.tsx
+++ b/src/components/Market/MarketOutcomes.tsx
@@ -13,6 +13,7 @@ import {
   useAppDispatch,
   useAppSelector,
   useExpandableOutcomes,
+  usePredictedOutcome,
   useTrade
 } from 'hooks';
 
@@ -39,15 +40,9 @@ export default function MarketOutcomes({
   const location = useLocation();
   const dispatch = useAppDispatch();
   const trade = useAppSelector(state => state.trade);
-  const portfolio = useAppSelector(state => state.polkamarkets.portfolio);
+  const predictedOutcome = usePredictedOutcome(market.id);
   const theme = useTheme();
   const { trade: tradeState, status } = useTrade();
-
-  const isPredictedOutcome = useCallback(
-    (outcomeId: string | number) =>
-      portfolio[market.id]?.outcomes[outcomeId]?.shares >= 0.0005,
-    [market.id, portfolio]
-  );
 
   const [tradeVisible, setTradeVisible] = useState(false);
 
@@ -78,12 +73,24 @@ export default function MarketOutcomes({
   const setOutcome = useCallback(
     async (outcomeId: string) => {
       const { marketSelected } = await import('redux/ducks/market');
-      const { selectOutcome } = await import('redux/ducks/trade');
+      const { changeTradeType, selectOutcome } = await import(
+        'redux/ducks/trade'
+      );
+      const hasPredictedOutcome =
+        !!predictedOutcome && features.fantasy.enabled;
 
       dispatch(marketSelected(market));
-      dispatch(selectOutcome(market.id, market.networkId, outcomeId));
+      dispatch(
+        selectOutcome(
+          market.id,
+          market.networkId,
+          hasPredictedOutcome ? predictedOutcome : outcomeId
+        )
+      );
+
+      if (hasPredictedOutcome) dispatch(changeTradeType('sell'));
     },
-    [dispatch, market]
+    [dispatch, market, predictedOutcome]
   );
 
   const handleOutcomeClick = useCallback(
@@ -233,7 +240,7 @@ export default function MarketOutcomes({
               value={outcome.id}
               data={outcome.data}
               primary={outcome.title}
-              isPredicted={isPredictedOutcome(outcome.id)}
+              isPredicted={predictedOutcome === outcome.id.toString()}
               isActive={getOutcomeActive(outcome.id)}
               onClick={handleOutcomeClick}
               secondary={{
@@ -256,8 +263,8 @@ export default function MarketOutcomes({
           <OutcomeItem
             $size="sm"
             $variant="dashed"
-            isPredicted={expandableOutcomes.off.some(outcome =>
-              isPredictedOutcome(outcome.id)
+            isPredicted={expandableOutcomes.off.some(
+              outcome => predictedOutcome === outcome.id.toString()
             )}
             value={expandableOutcomes.onseted[0].id}
             onClick={handleOutcomeClick}

--- a/src/components/Trade/Trade.tsx
+++ b/src/components/Trade/Trade.tsx
@@ -1,13 +1,16 @@
-import { CSSProperties } from 'react';
+import { CSSProperties, useCallback, useMemo } from 'react';
 
 import cn from 'classnames';
 import { features } from 'config';
 import getMarketColors from 'helpers/getMarketColors';
+import { changeTradeType, selectOutcome } from 'redux/ducks/trade';
 import { useTheme } from 'ui';
 
-import { useAppSelector } from 'hooks';
+import { useAppDispatch, useAppSelector, useLanguage } from 'hooks';
 
+import { AlertMini } from '../Alert';
 import Breadcrumb from '../Breadcrumb';
+import { Button } from '../Button';
 import TradeFormClosed from '../TradeForm/TradeFormClosed';
 import TradeFormInput from '../TradeForm/TradeFormInput';
 import { views } from './Trade.config';
@@ -23,10 +26,20 @@ type TradeProps = {
 };
 
 function Trade({ view = 'default', onTradeFinished }: TradeProps) {
+  const dispatch = useAppDispatch();
   const theme = useTheme();
+  const language = useLanguage();
   const market = useAppSelector(state => state.market.market);
   const isLoadingMarket = useAppSelector(state => state.market.isLoading);
 
+  const type = useAppSelector(state => state.trade.type);
+  const predictionId = useAppSelector(state => state.trade.selectedOutcomeId);
+  const marketId = useAppSelector(state => state.trade.selectedMarketId);
+  const marketNetworkId = useAppSelector(
+    state => state.market.market.networkId
+  );
+
+  const portfolio = useAppSelector(state => state.polkamarkets.portfolio);
   const { login: isLoadingLogin, portfolio: isLoadingPortfolio } =
     useAppSelector(state => state.polkamarkets.isLoading);
 
@@ -36,6 +49,53 @@ function Trade({ view = 'default', onTradeFinished }: TradeProps) {
   });
 
   const config = views[view];
+
+  const outcomesWithShares = useMemo(() => {
+    if (isLoadingPortfolio) return [];
+
+    const marketShares = portfolio[marketId];
+
+    if (!marketShares) return [];
+
+    const sharesByOutcome = market.outcomes.map(outcome => {
+      const outcomeShares = marketShares.outcomes[outcome.id];
+
+      return {
+        id: outcome.id.toString(),
+        title: outcome.title,
+        shares: outcomeShares ? outcomeShares.shares : 0
+      };
+    });
+
+    return sharesByOutcome.filter(outcome => outcome.shares > 1e-5);
+  }, [isLoadingPortfolio, portfolio, marketId, market.outcomes]);
+
+  const hasSharesOfOtherOutcomes = useMemo(
+    () =>
+      !!outcomesWithShares.find(
+        outcome => outcome.id !== predictionId.toString()
+      ),
+    [outcomesWithShares, predictionId]
+  );
+
+  const prediction = useMemo(
+    () =>
+      market.outcomes.find(
+        outcome => outcome.id.toString() === predictionId.toString()
+      ),
+    [market.outcomes, predictionId]
+  );
+
+  const handleSellShares = useCallback(
+    (outcomeId: string) => {
+      if (type !== 'sell') {
+        dispatch(changeTradeType('sell'));
+      }
+
+      dispatch(selectOutcome(marketId, marketNetworkId, outcomeId));
+    },
+    [dispatch, marketId, marketNetworkId, type]
+  );
 
   if (isLoadingMarket) return null;
 
@@ -81,21 +141,46 @@ function Trade({ view = 'default', onTradeFinished }: TradeProps) {
         </div>
       ) : (
         <div className={styles.rootActions}>
-          <TradeFormInput />
-          <TradeDetails />
-          <div className={styles.actionsGroup}>
-            <TradeActions onTradeFinished={onTradeFinished} />
-            <p className={styles.terms}>
-              By clicking you’re agreeing to our{' '}
-              <a
-                href="https://www.polkamarkets.com/legal/terms-conditions"
-                target="_blank"
-                rel="noreferrer"
+          {features.fantasy.enabled &&
+          hasSharesOfOtherOutcomes &&
+          prediction ? (
+            <div className="flex-column gap-5 width-full">
+              <AlertMini
+                variant="warning"
+                description={
+                  language === 'pt'
+                    ? `Só podes escolher um resultado de cada vez. Para mudar a tua previsão para "${prediction.title}", tens que vender a tua previsão "${outcomesWithShares[0].title}".`
+                    : `You can only buy shares of one outcome at a time. In order to buy shares of "${prediction.title}" you need to sell your position of "${outcomesWithShares[0].title}".`
+                }
+                descriptionClasses="notranslate"
+              />
+              <Button
+                color="danger"
+                fullwidth
+                onClick={() => handleSellShares(outcomesWithShares[0].id)}
               >
-                Terms and Conditions
-              </a>
-            </p>
-          </div>
+                Sell
+              </Button>
+            </div>
+          ) : (
+            <>
+              <TradeFormInput />
+              <TradeDetails />
+              <div className={styles.actionsGroup}>
+                <TradeActions onTradeFinished={onTradeFinished} />
+                <p className={styles.terms}>
+                  By clicking you’re agreeing to our{' '}
+                  <a
+                    href="https://www.polkamarkets.com/legal/terms-conditions"
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    Terms and Conditions
+                  </a>
+                </p>
+              </div>
+            </>
+          )}
         </div>
       )}
     </div>

--- a/src/components/Trade/Trade.tsx
+++ b/src/components/Trade/Trade.tsx
@@ -1,16 +1,13 @@
-import { CSSProperties, useCallback, useMemo } from 'react';
+import { CSSProperties } from 'react';
 
 import cn from 'classnames';
 import { features } from 'config';
 import getMarketColors from 'helpers/getMarketColors';
-import { changeTradeType, selectOutcome } from 'redux/ducks/trade';
 import { useTheme } from 'ui';
 
-import { useAppDispatch, useAppSelector, useLanguage } from 'hooks';
+import { useAppSelector } from 'hooks';
 
-import { AlertMini } from '../Alert';
 import Breadcrumb from '../Breadcrumb';
-import { Button } from '../Button';
 import TradeFormClosed from '../TradeForm/TradeFormClosed';
 import TradeFormInput from '../TradeForm/TradeFormInput';
 import { views } from './Trade.config';
@@ -26,20 +23,10 @@ type TradeProps = {
 };
 
 function Trade({ view = 'default', onTradeFinished }: TradeProps) {
-  const dispatch = useAppDispatch();
   const theme = useTheme();
-  const language = useLanguage();
   const market = useAppSelector(state => state.market.market);
   const isLoadingMarket = useAppSelector(state => state.market.isLoading);
 
-  const type = useAppSelector(state => state.trade.type);
-  const predictionId = useAppSelector(state => state.trade.selectedOutcomeId);
-  const marketId = useAppSelector(state => state.trade.selectedMarketId);
-  const marketNetworkId = useAppSelector(
-    state => state.market.market.networkId
-  );
-
-  const portfolio = useAppSelector(state => state.polkamarkets.portfolio);
   const { login: isLoadingLogin, portfolio: isLoadingPortfolio } =
     useAppSelector(state => state.polkamarkets.isLoading);
 
@@ -49,53 +36,6 @@ function Trade({ view = 'default', onTradeFinished }: TradeProps) {
   });
 
   const config = views[view];
-
-  const outcomesWithShares = useMemo(() => {
-    if (isLoadingPortfolio) return [];
-
-    const marketShares = portfolio[marketId];
-
-    if (!marketShares) return [];
-
-    const sharesByOutcome = market.outcomes.map(outcome => {
-      const outcomeShares = marketShares.outcomes[outcome.id];
-
-      return {
-        id: outcome.id.toString(),
-        title: outcome.title,
-        shares: outcomeShares ? outcomeShares.shares : 0
-      };
-    });
-
-    return sharesByOutcome.filter(outcome => outcome.shares > 1e-5);
-  }, [isLoadingPortfolio, portfolio, marketId, market.outcomes]);
-
-  const hasSharesOfOtherOutcomes = useMemo(
-    () =>
-      !!outcomesWithShares.find(
-        outcome => outcome.id !== predictionId.toString()
-      ),
-    [outcomesWithShares, predictionId]
-  );
-
-  const prediction = useMemo(
-    () =>
-      market.outcomes.find(
-        outcome => outcome.id.toString() === predictionId.toString()
-      ),
-    [market.outcomes, predictionId]
-  );
-
-  const handleSellShares = useCallback(
-    (outcomeId: string) => {
-      if (type !== 'sell') {
-        dispatch(changeTradeType('sell'));
-      }
-
-      dispatch(selectOutcome(marketId, marketNetworkId, outcomeId));
-    },
-    [dispatch, marketId, marketNetworkId, type]
-  );
 
   if (isLoadingMarket) return null;
 
@@ -141,46 +81,21 @@ function Trade({ view = 'default', onTradeFinished }: TradeProps) {
         </div>
       ) : (
         <div className={styles.rootActions}>
-          {features.fantasy.enabled &&
-          hasSharesOfOtherOutcomes &&
-          prediction ? (
-            <div className="flex-column gap-5 width-full">
-              <AlertMini
-                variant="warning"
-                description={
-                  language === 'pt'
-                    ? `Só podes escolher um resultado de cada vez. Para mudar a tua previsão para "${prediction.title}", tens que vender a tua previsão "${outcomesWithShares[0].title}".`
-                    : `You can only buy shares of one outcome at a time. In order to buy shares of "${prediction.title}" you need to sell your position of "${outcomesWithShares[0].title}".`
-                }
-                descriptionClasses="notranslate"
-              />
-              <Button
-                color="danger"
-                fullwidth
-                onClick={() => handleSellShares(outcomesWithShares[0].id)}
+          <TradeFormInput />
+          <TradeDetails />
+          <div className={styles.actionsGroup}>
+            <TradeActions onTradeFinished={onTradeFinished} />
+            <p className={styles.terms}>
+              By clicking you’re agreeing to our{' '}
+              <a
+                href="https://www.polkamarkets.com/legal/terms-conditions"
+                target="_blank"
+                rel="noreferrer"
               >
-                Sell
-              </Button>
-            </div>
-          ) : (
-            <>
-              <TradeFormInput />
-              <TradeDetails />
-              <div className={styles.actionsGroup}>
-                <TradeActions onTradeFinished={onTradeFinished} />
-                <p className={styles.terms}>
-                  By clicking you’re agreeing to our{' '}
-                  <a
-                    href="https://www.polkamarkets.com/legal/terms-conditions"
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    Terms and Conditions
-                  </a>
-                </p>
-              </div>
-            </>
-          )}
+                Terms and Conditions
+              </a>
+            </p>
+          </div>
         </div>
       )}
     </div>

--- a/src/components/Trade/TradePredictions.tsx
+++ b/src/components/Trade/TradePredictions.tsx
@@ -7,7 +7,7 @@ import sortOutcomes from 'helpers/sortOutcomes';
 import { selectOutcome } from 'redux/ducks/trade';
 import { Image } from 'ui';
 
-import { useAppDispatch, useAppSelector } from 'hooks';
+import { useAppDispatch, useAppSelector, usePredictedOutcome } from 'hooks';
 
 import styles from './Trade.module.scss';
 import { View } from './Trade.types';
@@ -26,12 +26,16 @@ function TradePredictions({
 }: TradePredictionsProps) {
   const dispatch = useAppDispatch();
 
-  const { id, outcomes, networkId } = useAppSelector(
-    state => state.market.market
-  );
+  const id = useAppSelector(state => state.market.market.id);
+  const outcomes = useAppSelector(state => state.market.market.outcomes);
+  const networkId = useAppSelector(state => state.market.market.networkId);
+  const predictedOutcome = usePredictedOutcome(id);
 
-  const { selectedOutcomeId, selectedMarketId } = useAppSelector(
-    state => state.trade
+  const selectedOutcomeId = useAppSelector(
+    state => state.trade.selectedOutcomeId
+  );
+  const selectedMarketId = useAppSelector(
+    state => state.trade.selectedMarketId
   );
 
   const handleSelectOutcome = useCallback(
@@ -72,6 +76,7 @@ function TradePredictions({
           data={predictions}
           itemContent={(index, outcome) => (
             <button
+              key={outcome.name}
               type="button"
               className={cn(styles.prediction, {
                 [styles.predictionLg]: size === 'lg',
@@ -85,6 +90,7 @@ function TradePredictions({
               })}
               value={outcome.id.toString()}
               onClick={handleSelectOutcome}
+              disabled={predictedOutcome !== outcome.id.toString()}
             >
               <div
                 className={cn(styles.predictionProgress, {

--- a/src/components/Trade/TradePredictions.tsx
+++ b/src/components/Trade/TradePredictions.tsx
@@ -7,7 +7,7 @@ import sortOutcomes from 'helpers/sortOutcomes';
 import { selectOutcome } from 'redux/ducks/trade';
 import { Image } from 'ui';
 
-import { useAppDispatch, useAppSelector, usePredictedOutcome } from 'hooks';
+import { useAppDispatch, useAppSelector } from 'hooks';
 
 import styles from './Trade.module.scss';
 import { View } from './Trade.types';
@@ -29,7 +29,6 @@ function TradePredictions({
   const id = useAppSelector(state => state.market.market.id);
   const outcomes = useAppSelector(state => state.market.market.outcomes);
   const networkId = useAppSelector(state => state.market.market.networkId);
-  const predictedOutcome = usePredictedOutcome(id);
 
   const selectedOutcomeId = useAppSelector(
     state => state.trade.selectedOutcomeId
@@ -90,7 +89,6 @@ function TradePredictions({
               })}
               value={outcome.id.toString()}
               onClick={handleSelectOutcome}
-              disabled={predictedOutcome !== outcome.id.toString()}
             >
               <div
                 className={cn(styles.predictionProgress, {

--- a/src/components/Trade/TradePredictionsWithImages.tsx
+++ b/src/components/Trade/TradePredictionsWithImages.tsx
@@ -16,7 +16,7 @@ import { Line } from 'rc-progress';
 import { selectOutcome } from 'redux/ducks/trade';
 import { Image } from 'ui';
 
-import { useAppDispatch, useAppSelector, usePredictedOutcome } from 'hooks';
+import { useAppDispatch, useAppSelector } from 'hooks';
 
 import Icon from '../Icon';
 import styles from './Trade.module.scss';
@@ -64,7 +64,6 @@ function TradePredictionsWithImages({
 
   const id = useAppSelector(state => state.market.market.id);
   const networkId = useAppSelector(state => state.market.market.networkId);
-  const predictedOutcome = usePredictedOutcome(id);
 
   const selectedOutcomeId = useAppSelector(
     state => state.trade.selectedOutcomeId
@@ -148,7 +147,6 @@ function TradePredictionsWithImages({
           })}
           value={prediction.id.toString()}
           onClick={handleSelectPrediction}
-          disabled={predictedOutcome !== prediction.id.toString()}
         >
           <div className={styles.predictionWithImageProgressWrapper}>
             <Image

--- a/src/components/Trade/TradePredictionsWithImages.tsx
+++ b/src/components/Trade/TradePredictionsWithImages.tsx
@@ -16,7 +16,7 @@ import { Line } from 'rc-progress';
 import { selectOutcome } from 'redux/ducks/trade';
 import { Image } from 'ui';
 
-import { useAppDispatch, useAppSelector } from 'hooks';
+import { useAppDispatch, useAppSelector, usePredictedOutcome } from 'hooks';
 
 import Icon from '../Icon';
 import styles from './Trade.module.scss';
@@ -62,10 +62,15 @@ function TradePredictionsWithImages({
 }: TradePredictionsWithImagesProps) {
   const dispatch = useAppDispatch();
 
-  const { id, networkId } = useAppSelector(state => state.market.market);
+  const id = useAppSelector(state => state.market.market.id);
+  const networkId = useAppSelector(state => state.market.market.networkId);
+  const predictedOutcome = usePredictedOutcome(id);
 
-  const { selectedOutcomeId, selectedMarketId } = useAppSelector(
-    state => state.trade
+  const selectedOutcomeId = useAppSelector(
+    state => state.trade.selectedOutcomeId
+  );
+  const selectedMarketId = useAppSelector(
+    state => state.trade.selectedMarketId
   );
 
   const apiRef = useRef({} as scrollVisibilityApiType);
@@ -143,6 +148,7 @@ function TradePredictionsWithImages({
           })}
           value={prediction.id.toString()}
           onClick={handleSelectPrediction}
+          disabled={predictedOutcome !== prediction.id.toString()}
         >
           <div className={styles.predictionWithImageProgressWrapper}>
             <Image

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -38,6 +38,8 @@ export { default as useMount } from './useMount';
 
 export { default as usePortal } from './usePortal';
 
+export { default as usePredictedOutcome } from './usePredictedOutcome';
+
 export { default as usePrevious } from './usePrevious';
 
 export { default as useTimeoutEffect } from './useTimeoutEffect';

--- a/src/hooks/usePredictedOutcome/index.ts
+++ b/src/hooks/usePredictedOutcome/index.ts
@@ -1,0 +1,1 @@
+export { default } from './usePredictedOutcome';

--- a/src/hooks/usePredictedOutcome/usePredictedOutcome.ts
+++ b/src/hooks/usePredictedOutcome/usePredictedOutcome.ts
@@ -2,19 +2,16 @@ import useAppSelector from 'hooks/useAppSelector';
 
 type Outcomes = Record<number, Record<'shares' | 'price', number>>;
 
+const defaultPredictedOutcome = '';
+
 export default function usePredictedOutcome(marketId: string) {
   const portfolio = useAppSelector(state => state.polkamarkets.portfolio);
+  const market = portfolio[marketId];
 
-  let predictedOutcomeId = '';
+  if (!market) return defaultPredictedOutcome;
 
-  if (!portfolio[marketId]) return predictedOutcomeId;
-
-  // eslint-disable-next-line no-restricted-syntax
-  for (const [key, { shares }] of Object.entries(
-    portfolio[marketId].outcomes as Outcomes
-  )) {
-    if (shares >= 0.0005) predictedOutcomeId = key;
-  }
-
-  return predictedOutcomeId;
+  return Object.entries(market.outcomes as Outcomes).reduce(
+    (acc, [id, { shares }]) => (shares > 1e-5 ? id : acc),
+    defaultPredictedOutcome
+  );
 }

--- a/src/hooks/usePredictedOutcome/usePredictedOutcome.ts
+++ b/src/hooks/usePredictedOutcome/usePredictedOutcome.ts
@@ -1,0 +1,20 @@
+import useAppSelector from 'hooks/useAppSelector';
+
+type Outcomes = Record<number, Record<'shares' | 'price', number>>;
+
+export default function usePredictedOutcome(marketId: string) {
+  const portfolio = useAppSelector(state => state.polkamarkets.portfolio);
+
+  let predictedOutcomeId = '';
+
+  if (!portfolio[marketId]) return predictedOutcomeId;
+
+  // eslint-disable-next-line no-restricted-syntax
+  for (const [key, { shares }] of Object.entries(
+    portfolio[marketId].outcomes as Outcomes
+  )) {
+    if (shares >= 0.0005) predictedOutcomeId = key;
+  }
+
+  return predictedOutcomeId;
+}

--- a/src/styles/base/_reset.scss
+++ b/src/styles/base/_reset.scss
@@ -157,3 +157,8 @@ button {
 [role='button'] {
   cursor: pointer;
 }
+
+button:disabled {
+  pointer-events: none;
+  cursor: default;
+}


### PR DESCRIPTION
## 🗃 Story Description

[ENG-232](https://linear.app/polkamarkets-labs/issue/ENG-232/prediction-modal-change-highlighted-outcome-when-selling-a-prediction)

## 🧪 Test Suite
- Navbar Actions
  - [ ] Switch between light and dark mode across pages
  - [ ] Network Switcher
  - [ ] Wrong Network Modal
- Homepage Markets Navigation
  - [ ] Filters
  - [ ] Sorting
  - [ ] Search
- Pages Content
  - [ ] Homepage
  - [ ] Create Market Page
  - [ ] Market Page
  - [ ] Portfolio
- Trading (**Optional** - only if PR involves related components or `polkamarkets-js`)
  - [x] Slider + MAX button
  - [x] Buy Outcome Shares
  - [x] Sell Outcome Shares
  - [x] Add Liquidity 
  - [x] Remove Liquidity
 
  ## 📝 Footnotes
  _Noting to add._
