### PR TITLE
[ENG-239] Show only the outcome to sell in the Prediction Modal

### DIFF
--- a/src/components/Trade/Trade.tsx
+++ b/src/components/Trade/Trade.tsx
@@ -68,7 +68,7 @@ function Trade({ view = 'default', onTradeFinished }: TradeProps) {
       };
     });
 
-    return sharesByOutcome.filter(outcome => outcome.shares > 1e-5);
+    return sharesByOutcome.filter(outcome => outcome.shares > 1e-4);
   }, [isLoadingPortfolio, portfolio, marketId, market.outcomes]);
 
   const hasSharesOfOtherOutcomes = useMemo(
@@ -147,7 +147,11 @@ function Trade({ view = 'default', onTradeFinished }: TradeProps) {
         ) : null}
         <TradePredictions
           view={view}
-          filterBy={hasSharesOfOtherOutcomes ? filterByHaveShares : undefined}
+          filterBy={
+            hasSharesOfOtherOutcomes || type === 'sell'
+              ? filterByHaveShares
+              : undefined
+          }
         />
       </div>
       {features.fantasy.enabled && (isLoadingLogin || isLoadingPortfolio) ? (


### PR DESCRIPTION
## 🗃 Story Description

[ENG-239](https://linear.app/polkamarkets-labs/issue/ENG-239/show-only-the-outcome-to-sell-in-the-prediction-modal) 

## 🧪 Test Suite
- Navbar Actions
  - [ ] Switch between light and dark mode across pages
  - [ ] Network Switcher
  - [ ] Wrong Network Modal
- Homepage Markets Navigation
  - [ ] Filters
  - [ ] Sorting
  - [ ] Search
- Pages Content
  - [ ] Homepage
  - [ ] Create Market Page
  - [ ] Market Page
  - [ ] Portfolio
- Trading (**Optional** - only if PR involves related components or `polkamarkets-js`)
  - [x] Slider + MAX button
  - [x] Buy Outcome Shares
  - [x] Sell Outcome Shares
  - [x] Add Liquidity 
  - [x] Remove Liquidity
 
  ## 📝 Footnotes
  _Noting to add._
