### PR TITLE
[ENG-244] Remover padding em .pm-c-market-list

### DIFF
--- a/src/pages/Tournament/TournamentHero.module.scss
+++ b/src/pages/Tournament/TournamentHero.module.scss
@@ -1,7 +1,3 @@
-.wrapper {
-  margin-top: var(--size-24);
-}
-
 .root {
   display: flex;
   flex-direction: column;

--- a/src/styles/components/_market-list.scss
+++ b/src/styles/components/_market-list.scss
@@ -1,6 +1,8 @@
 .pm-c-market-list {
   flex: 1 1 auto;
-  padding: var(--grid-margin);
+  padding-bottom: var(--grid-margin);
+  padding-left: var(--grid-margin);
+  padding-right: var(--grid-margin);
 
   @media (min-width: 1440px) {
     padding-left: unset;


### PR DESCRIPTION
## 🗃 Story Description

 [ENG-244](https://linear.app/polkamarkets-labs/issue/ENG-244/remover-padding-em-pm-c-market-list)

## 🧪 Test Suite
- Navbar Actions
  - [ ] Switch between light and dark mode across pages
  - [ ] Network Switcher
  - [ ] Wrong Network Modal
- Homepage Markets Navigation
  - [ ] Filters
  - [ ] Sorting
  - [ ] Search
- Pages Content
  - [ ] Homepage
  - [ ] Create Market Page
  - [ ] Market Page
  - [ ] Portfolio
- Trading (**Optional** - only if PR involves related components or `polkamarkets-js`)
  - [ ] Slider + MAX button
  - [ ] Buy Outcome Shares
  - [ ] Sell Outcome Shares
  - [ ] Add Liquidity 
  - [ ] Remove Liquidity
 
  ## 📝 Footnotes
  _Noting to add._
