### PR TITLE
[ENG-205] Outcome in market trade modal is showing wrong colors

### DIFF
--- a/src/components/Trade/TradePredictions.tsx
+++ b/src/components/Trade/TradePredictions.tsx
@@ -67,7 +67,6 @@ function TradePredictions({
     [outcomes]
   );
 
-  const multiple = predictions.length > 2;
   const withImages = predictions.every(outcome => !!outcome.imageUrl);
 
   const listHeight = Math.min(
@@ -102,9 +101,8 @@ function TradePredictions({
             >
               <div
                 className={cn(styles.predictionProgress, {
-                  [styles.predictionProgressDefault]: multiple,
-                  [styles.predictionProgressWinning]: !multiple && index === 0,
-                  [styles.predictionProgressLosing]: !multiple && index === 1
+                  [styles.predictionProgressWinning]: outcome.isPriceUp,
+                  [styles.predictionProgressLosing]: !outcome.isPriceUp
                 })}
                 style={{
                   width: `${outcome.price * 100}%`

--- a/src/components/Trade/TradePredictionsWithImages.tsx
+++ b/src/components/Trade/TradePredictionsWithImages.tsx
@@ -11,7 +11,7 @@ import { ScrollMenu, VisibilityContext } from 'react-horizontal-scrolling-menu';
 
 import cn from 'classnames';
 import { roundNumber } from 'helpers/math';
-import { Outcome } from 'models/market';
+import type { SortedOutcomes } from 'helpers/sortOutcomes';
 import { Line } from 'rc-progress';
 import { selectOutcome } from 'redux/ducks/trade';
 import { Image } from 'ui';
@@ -54,7 +54,7 @@ function RightArrow() {
 type scrollVisibilityApiType = ContextType<typeof VisibilityContext>;
 
 type TradePredictionsWithImagesProps = {
-  predictions: Outcome[];
+  predictions: SortedOutcomes;
 };
 
 function TradePredictionsWithImages({
@@ -130,7 +130,7 @@ function TradePredictionsWithImages({
       RightArrow={multiple ? RightArrow : undefined}
       onWheel={onWheel}
     >
-      {predictions.map((prediction, index) => (
+      {predictions.map(prediction => (
         <button
           type="button"
           key={prediction.id.toString()}
@@ -156,11 +156,10 @@ function TradePredictionsWithImages({
               strokeWidth={6}
               percent={prediction.price * 100}
               className={cn(styles.predictionWithImageProgress, {
-                [styles.predictionWithImageProgressDefault]: multiple,
                 [styles.predictionWithImageProgressWinning]:
-                  !multiple && index === 0,
+                  prediction.isPriceUp,
                 [styles.predictionWithImageProgressLosing]:
-                  !multiple && index === 1
+                  !prediction.isPriceUp
               })}
             />
           </div>

--- a/src/helpers/sortOutcomes.ts
+++ b/src/helpers/sortOutcomes.ts
@@ -52,7 +52,7 @@ export default function sortOutcomes(args: SortOutcomes) {
         ...outcome,
         price: +outcome.price.toFixed(3) * Math.sign(outcome.price),
         pricesDiff: getPricesDiff(priceChart),
-        isPriceUp: !priceChart?.changePercent || priceChart?.changePercent > 0,
+        isPriceUp: outcome.priceChange24h > 0,
         name: outcome.title,
         data: fromPriceChartToLineChartSeries(priceChart?.prices || [])
       };

--- a/src/hooks/useExpandableOutcomes/useExpandableOutcomes.ts
+++ b/src/hooks/useExpandableOutcomes/useExpandableOutcomes.ts
@@ -21,11 +21,10 @@ export default function useExpandableOutcomes({
     offseted: {
       primary: `${off.length}+ Outcomes`,
       secondary: {
-        text: `${off.map(outcome => outcome.title).join(', ')}`,
-        price: +(
-          off.reduce((prices, outcome) => outcome.price + prices, 0) /
-          off.length
-        ).toFixed(3)
+        text: off.map(outcome => outcome.title).join(', '),
+        price: +off
+          .reduce((prices, outcome) => outcome.price + prices, 0)
+          .toFixed(3)
       }
     },
     off


### PR DESCRIPTION
## 🗃 Story Description

[ENG-205](https://linear.app/polkamarkets-labs/issue/ENG-205/outcome-in-market-trade-modal-is-showing-wrong-colors)

## 🧪 Test Suite
- Navbar Actions
  - [ ] Switch between light and dark mode across pages
  - [ ] Network Switcher
  - [ ] Wrong Network Modal
- Homepage Markets Navigation
  - [ ] Filters
  - [ ] Sorting
  - [ ] Search
- Pages Content
  - [ ] Homepage
  - [ ] Create Market Page
  - [ ] Market Page
  - [ ] Portfolio
- Trading (**Optional** - only if PR involves related components or `polkamarkets-js`)
  - [ ] Slider + MAX button
  - [ ] Buy Outcome Shares
  - [ ] Sell Outcome Shares
  - [ ] Add Liquidity 
  - [ ] Remove Liquidity
 
  ## 📝 Footnotes
  _Noting to add._
