### PR TITLE
[ENG-248] Adicionar possibilidade de fazer swipe no cards de onboarding em mobile

### DIFF
--- a/src/components/Header/HeaderNav.tsx
+++ b/src/components/Header/HeaderNav.tsx
@@ -160,27 +160,25 @@ function HeaderNavMenuModal() {
     <HeaderNavModal>
       {handleHide => (
         <HeaderNavMenu onMenuItemClick={handleHide}>
-          {features.fantasy.enabled &&
-            !isLoggedIn &&
-            (ui.layout.header.helpUrl || ui.layout.onboarding) && (
-              <>
-                {ui.layout.header.helpUrl && (
-                  <li className={headerNavClasses.item}>
-                    <HelpButton
-                      $outline
-                      $fullWidth
-                      onClick={handleHide}
-                      href={ui.layout.header.helpUrl}
-                    />
-                  </li>
-                )}
-                {!!ui.layout.onboarding && (
-                  <li className={headerNavClasses.item}>
-                    <HowToPlayButton $outline $fullWidth />
-                  </li>
-                )}
-              </>
-            )}
+          {features.fantasy.enabled && !isLoggedIn && (
+            <>
+              {ui.layout.header.helpUrl && (
+                <li className={headerNavClasses.item}>
+                  <HelpButton
+                    $outline
+                    $fullWidth
+                    onClick={handleHide}
+                    href={ui.layout.header.helpUrl}
+                  />
+                </li>
+              )}
+              {ui.layout.onboarding.steps && (
+                <li className={headerNavClasses.item}>
+                  <HowToPlayButton $outline $fullWidth />
+                </li>
+              )}
+            </>
+          )}
         </HeaderNavMenu>
       )}
     </HeaderNavModal>

--- a/src/components/HowToPlayButton/HowToPlayButton.tsx
+++ b/src/components/HowToPlayButton/HowToPlayButton.tsx
@@ -1,3 +1,5 @@
+import { useCallback } from 'react';
+
 import cn from 'classnames';
 
 import Icon from 'components/Icon';
@@ -21,8 +23,13 @@ export default function HowToPlayButton({
   $outline,
   ...props
 }: HowToPlayButtonProps) {
-  const [_onboardingCompleted, setOnboardingCompleted] =
-    useLocalStorage<boolean>('onboardingCompleted', false);
+  const [_, setOnboarding] = useLocalStorage<boolean>(
+    'onboardingCompleted',
+    false
+  );
+  const handleCompleted = useCallback(() => {
+    setOnboarding(false);
+  }, [setOnboarding]);
 
   return (
     <button
@@ -37,7 +44,7 @@ export default function HowToPlayButton({
         },
         className
       )}
-      onClick={() => setOnboardingCompleted(false)}
+      onClick={handleCompleted}
       {...props}
     >
       <Icon name="Question" size="lg" className={styles.icon} />

--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -37,7 +37,9 @@ export default function Layout({ children }: React.PropsWithChildren<{}>) {
   return (
     <div className={layoutClasses.root}>
       {page?.meta && <SEO {...page.meta} />}
-      {ui.layout.onboarding.steps && <Onboarding />}
+      {ui.layout.onboarding.steps && (
+        <Onboarding steps={ui.layout.onboarding.steps} />
+      )}
       {ui.layout.disclaimer.enabled && <BetaWarning />}
       {ui.layout.alert.enabled && <BetaTesting network={network} />}
       {!ui.socialLogin.enabled && !isAllowedNetwork && (

--- a/src/components/Onboarding/Onboarding.module.scss
+++ b/src/components/Onboarding/Onboarding.module.scss
@@ -1,5 +1,6 @@
 .header {
   margin-bottom: var(--size-32);
+  height: 64px;
 }
 
 .title {
@@ -17,38 +18,42 @@
 }
 
 .footer {
-  display: flex;
   flex-direction: column;
+  margin-top: auto;
 }
 
 .steps {
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  align-items: center;
-
-  gap: var(--size-16);
-
-  margin-bottom: var(--size-24);
+  text-align: center;
+  margin-bottom: var(--size-8);
 
   &Item {
-    height: 10px;
-    width: 10px;
+    display: inline;
 
-    flex-shrink: 0;
-    aspect-ratio: 1/1;
+    &:not(:last-child) {
+      margin-right: 16px;
+    }
 
-    background-color: #f2f4f7 !important;
-    opacity: 0.32;
-    border-radius: 6px;
+    &Button {
+      --channel-alpha: 0.32;
 
-    transition: background-color, opacity 0.2s ease-in-out;
+      height: 10px;
+      width: 10px;
 
-    &Active {
-      @composes .stepsItem;
+      background-color: rgb(250 250 250 / var(--channel-alpha));
+      border-radius: 5px;
+      border: 0;
 
-      background-color: #fafafa !important;
-      opacity: 1;
+      transition: background-color 200ms ease-in-out;
+
+      &Active {
+        --channel-alpha: 1;
+      }
     }
   }
+}
+
+.content {
+  height: 412px;
+  display: flex;
+  flex-direction: column;
 }

--- a/src/components/Onboarding/Onboarding.tsx
+++ b/src/components/Onboarding/Onboarding.tsx
@@ -1,8 +1,7 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useState } from 'react';
 
 import classNames from 'classnames';
-import { ui } from 'config';
-import isEmpty from 'lodash/isEmpty';
+import { AnimatePresence, motion } from 'framer-motion';
 import { Avatar } from 'ui';
 
 import { Button } from 'components/Button';
@@ -18,119 +17,138 @@ import ModalSectionText from 'components/ModalSectionText';
 import { useLocalStorage } from 'hooks';
 
 import styles from './Onboarding.module.scss';
-import { buildOnboardingSteps } from './Onboarding.utils';
+import type { OnboardingProps } from './Onboarding.type';
+import {
+  ARIA,
+  getSwipePower,
+  swipeThreshold,
+  variants,
+  wrap
+} from './Onboarding.utils';
 
-const ARIA = {
-  'aria-labelledby': 'onboarding-modal-name',
-  'aria-describedby': 'onboarding-modal-description'
-} as const;
-
-function Onboarding() {
-  const [show, setShow] = useState(false);
-  const [currentStep, setCurrentStep] = useState(0);
-
-  const [onboardingCompleted, setOnboardingCompleted] =
-    useLocalStorage<boolean>('onboardingCompleted', false);
-
-  useEffect(() => {
-    setShow(!onboardingCompleted);
-    setCurrentStep(0);
-  }, [onboardingCompleted]);
-
-  const onboardingSteps = useMemo(
-    () => buildOnboardingSteps(ui.layout.onboarding.steps),
-    []
+function Onboarding({ steps }: OnboardingProps) {
+  const [onboarding, setOnboarding] = useLocalStorage<boolean>(
+    'onboardingCompleted',
+    false
   );
+
+  const [[step, direction], setStep] = useState([0, 0]);
+
+  const isLastStep = steps.length - 1 === step;
+  const imageIndex = wrap(0, steps.length, step);
 
   const handleHide = useCallback(() => {
-    setOnboardingCompleted(true);
-    setShow(false);
-  }, [setOnboardingCompleted]);
-
-  const handleChangeStep = useCallback(
-    (step: number) => {
-      if (step > onboardingSteps.length - 1) {
-        handleHide();
-        return;
-      }
-
-      setCurrentStep(step);
+    setOnboarding(true);
+    setStep([0, 0]);
+  }, [setOnboarding]);
+  const handleStep = useCallback(
+    (newDirection: number) => {
+      if (isLastStep) handleHide();
+      else setStep([step + newDirection, newDirection]);
     },
-    [handleHide, onboardingSteps.length]
+    [handleHide, isLastStep, step]
   );
-
-  if (isEmpty(onboardingSteps)) return null;
-
-  const hasAtLeastOneImage = onboardingSteps.some(
-    ({ imageUrl }) => imageUrl !== null
-  );
-
-  const step = onboardingSteps[currentStep];
-  const isLastStep = currentStep === onboardingSteps.length - 1;
-
-  const { title, description, imageUrl } = step;
 
   return (
-    <Modal show={show} centered size="sm" onHide={handleHide}>
-      <ModalContent>
+    <Modal show={!onboarding} centered size="sm" onHide={handleHide}>
+      <ModalContent className={styles.content}>
         <ModalHeader>
           <ModalHeaderHide onClick={handleHide} />
-          <div className={styles.header}>
-            {imageUrl ? (
-              <Avatar $size="md" $radius="lg" src={imageUrl} alt={title} />
-            ) : (
-              <>
-                {hasAtLeastOneImage ? (
-                  <div style={{ height: 64, width: 64 }} />
-                ) : (
-                  <div style={{ height: 27, width: '100%' }} />
-                )}
-              </>
-            )}
-          </div>
-          <ModalHeaderTitle
-            id={ARIA['aria-labelledby']}
-            className={classNames(styles.title, 'pm-c-modal__header-title')}
-          >
-            {title}
-          </ModalHeaderTitle>
         </ModalHeader>
-        <ModalSection>
-          <ModalSectionText
-            id={ARIA['aria-describedby']}
-            className={classNames(
-              styles.description,
-              'pm-c-modal__section-description'
-            )}
+        <AnimatePresence>
+          <motion.div
+            key={step}
+            custom={direction}
+            variants={variants}
+            initial="enter"
+            animate="center"
+            exit="exit"
+            transition={{
+              x: {
+                type: 'spring',
+                stiffness: 300,
+                damping: 30
+              },
+              opacity: {
+                duration: 0.2
+              }
+            }}
+            drag="x"
+            dragConstraints={{
+              left: 0,
+              right: 0
+            }}
+            dragElastic={1}
+            onDragEnd={(_, { offset, velocity }) => {
+              const swipe = getSwipePower(offset.x, velocity.x);
+
+              if (swipe < -swipeThreshold) {
+                handleStep(1);
+              } else if (swipe > swipeThreshold) {
+                handleStep(-1);
+              }
+            }}
           >
-            {description}
-          </ModalSectionText>
-        </ModalSection>
-        <ModalFooter className={styles.footer}>
-          {onboardingSteps.length > 1 ? (
-            <div className={styles.steps}>
-              {onboardingSteps.map((item, index) => (
-                <button
-                  type="button"
-                  key={item.title}
-                  className={classNames(
-                    'pm-c-button',
-                    'pm-c-button-normal--noborder',
-                    styles.stepsItem,
-                    {
-                      [styles.stepsItemActive]: index === currentStep
-                    }
-                  )}
-                  onClick={() => setCurrentStep(index)}
+            <div className={styles.header}>
+              {steps[imageIndex].imageUrl && (
+                <Avatar
+                  $size="md"
+                  $radius="lg"
+                  src={steps[imageIndex].imageUrl}
+                  alt={steps[imageIndex].title}
                 />
-              ))}
+              )}
             </div>
-          ) : null}
+            <ModalHeaderTitle
+              id={ARIA['aria-labelledby']}
+              className={classNames(styles.title, 'pm-c-modal__header-title')}
+            >
+              {steps[imageIndex].title}
+            </ModalHeaderTitle>
+            <ModalSection>
+              <ModalSectionText
+                id={ARIA['aria-describedby']}
+                className={classNames(
+                  styles.description,
+                  'pm-c-modal__section-description'
+                )}
+              >
+                {steps[imageIndex].description}
+              </ModalSectionText>
+            </ModalSection>
+          </motion.div>
+        </AnimatePresence>
+        <ModalFooter className={styles.footer}>
+          {steps.length >= 2 && (
+            <ul className={styles.steps}>
+              {steps.map((item, index) => (
+                <li key={item.title} className={styles.stepsItem}>
+                  <button
+                    type="button"
+                    aria-label={`Go to step ${index + 1}`}
+                    className={classNames(styles.stepsItemButton, {
+                      [styles.stepsItemButtonActive]: index === step
+                    })}
+                    onClick={() => {
+                      handleStep(index > step ? 1 : -1);
+                      /*  if (index > step) {
+                          handleStep(1); 
+                        } else if (index < step) {
+                          handleStep(-1);
+                        } */
+                    }}
+                  />
+                </li>
+              ))}
+            </ul>
+          )}
           <Button
             size="sm"
             color="primary"
             fullwidth
-            onClick={() => handleChangeStep(currentStep + 1)}
+            onClick={() => {
+              handleStep(1);
+            }}
           >
             {isLastStep ? "Let's Go" : 'Next'}
           </Button>

--- a/src/components/Onboarding/Onboarding.type.ts
+++ b/src/components/Onboarding/Onboarding.type.ts
@@ -1,5 +1,5 @@
-export type Step = {
-  title: string;
-  description: string;
-  imageUrl: string | null;
+import { OnboardingSteps } from 'config/ui.utils';
+
+export type OnboardingProps = {
+  steps: OnboardingSteps;
 };

--- a/src/components/Onboarding/Onboarding.utils.ts
+++ b/src/components/Onboarding/Onboarding.utils.ts
@@ -1,26 +1,31 @@
-/* eslint-disable import/prefer-default-export */
-import { camelizeKeys } from 'humps';
+export const ARIA = {
+  'aria-labelledby': 'onboarding-modal-name',
+  'aria-describedby': 'onboarding-modal-description'
+};
+export const variants = {
+  enter: (direction: number) => ({
+    x: direction > 0 ? 1000 : -1000,
+    opacity: 0
+  }),
+  center: {
+    zIndex: 1,
+    x: 0,
+    opacity: 1
+  },
+  exit: (direction: number) => ({
+    zIndex: 0,
+    x: direction < 0 ? 1000 : -1000,
+    opacity: 0
+  })
+};
+export const swipeThreshold = 10000;
 
-import { Step } from './Onboarding.type';
+export function getSwipePower(offset: number, velocity: number) {
+  return Math.abs(offset) * velocity;
+}
+// ref: wrap from popmotion's lib
+export function wrap(min: number, max: number, v: number): number {
+  const rangeSize = max - min;
 
-export function buildOnboardingSteps(steps: string | undefined): Step[] {
-  if (!steps) {
-    return [];
-  }
-
-  try {
-    const parsedSteps = camelizeKeys(JSON.parse(steps));
-
-    const onboardingSteps = parsedSteps.filter(item =>
-      ['title', 'description'].every(key => item[key])
-    ) as Step[];
-
-    return onboardingSteps.map(({ title, description, imageUrl }) => ({
-      title,
-      description,
-      imageUrl: imageUrl || null
-    }));
-  } catch (error) {
-    return [];
-  }
+  return ((((v - min) % rangeSize) + rangeSize) % rangeSize) + min;
 }

--- a/src/config/ui.ts
+++ b/src/config/ui.ts
@@ -9,7 +9,11 @@ import {
 
 import environment from './environment';
 import features from './features';
-import { parseFiltersFromEnv, parseNavbarItemsFromEnv } from './ui.utils';
+import {
+  buildOnboardingSteps,
+  parseFiltersFromEnv,
+  parseNavbarItemsFromEnv
+} from './ui.utils';
 
 const providers = [
   'Google',
@@ -52,7 +56,7 @@ const ui = {
       }
     },
     onboarding: {
-      steps: environment.UI_ONBOARDING
+      steps: buildOnboardingSteps(environment.UI_ONBOARDING)
     },
     disclaimer: {
       enabled: features.regular.enabled

--- a/src/config/ui.utils.ts
+++ b/src/config/ui.utils.ts
@@ -1,3 +1,4 @@
+import { camelizeKeys } from 'humps';
 import has from 'lodash/has';
 
 type Filter = {
@@ -48,4 +49,19 @@ function parseNavbarItemsFromEnv(variable: string | undefined): NavbarItem[] {
   }
 }
 
-export { parseFiltersFromEnv, parseNavbarItemsFromEnv };
+export type OnboardingStep = Partial<
+  Record<'title' | 'description' | 'imageUrl', string>
+>;
+export type OnboardingSteps = Array<OnboardingStep>;
+
+function buildOnboardingSteps(steps?: string) {
+  if (typeof steps === 'undefined') return null;
+
+  try {
+    return camelizeKeys(JSON.parse(steps)) as OnboardingSteps;
+  } catch (error) {
+    return null;
+  }
+}
+
+export { parseFiltersFromEnv, parseNavbarItemsFromEnv, buildOnboardingSteps };


### PR DESCRIPTION
## 🗃 Story Description

[ENG-248](https://linear.app/polkamarkets-labs/issue/ENG-248/adicionar-possibilidade-de-fazer-swipe-no-cards-de-onboarding-em)

## 🧪 Test Suite
- Navbar Actions
  - [ ] Switch between light and dark mode across pages
  - [ ] Network Switcher
  - [ ] Wrong Network Modal
- Homepage Markets Navigation
  - [ ] Filters
  - [ ] Sorting
  - [ ] Search
- Pages Content
  - [ ] Homepage
  - [ ] Create Market Page
  - [ ] Market Page
  - [ ] Portfolio
- Trading (**Optional** - only if PR involves related components or `polkamarkets-js`)
  - [ ] Slider + MAX button
  - [ ] Buy Outcome Shares
  - [ ] Sell Outcome Shares
  - [ ] Add Liquidity 
  - [ ] Remove Liquidity
 
  ## 📝 Footnotes
  _Noting to add._
