### PR TITLE
[ENG-253] Adicionar padding nos cards a direita

### DIFF
--- a/src/styles/components/_prediction-card.scss
+++ b/src/styles/components/_prediction-card.scss
@@ -15,7 +15,7 @@
       padding: 16px var(--grid-margin);
 
       @include breakpoint-to('lg') {
-        @include flex-row(space-between, center);
+        @include flex-row(space-between, center, 5);
       }
     }
 


### PR DESCRIPTION
## 🗃 Story Description

[ENG-253](https://linear.app/polkamarkets-labs/issue/ENG-253/adicionar-padding-nos-cards-a-direita)

## 🧪 Test Suite
- Navbar Actions
  - [ ] Switch between light and dark mode across pages
  - [ ] Network Switcher
  - [ ] Wrong Network Modal
- Homepage Markets Navigation
  - [ ] Filters
  - [ ] Sorting
  - [ ] Search
- Pages Content
  - [ ] Homepage
  - [ ] Create Market Page
  - [ ] Market Page
  - [ ] Portfolio
- Trading (**Optional** - only if PR involves related components or `polkamarkets-js`)
  - [ ] Slider + MAX button
  - [ ] Buy Outcome Shares
  - [ ] Sell Outcome Shares
  - [ ] Add Liquidity 
  - [ ] Remove Liquidity
 
  ## 📝 Footnotes
  _Noting to add._
