### PR TITLE
[ENG-221] Tornar claro o conceito de Probabilidade no Previsómetro

### DIFF
--- a/src/pages/Market/Market.module.scss
+++ b/src/pages/Market/Market.module.scss
@@ -144,6 +144,10 @@
     text-transform: uppercase;
 
     color: #59749b;
+
+    &Caption {
+      float: right;
+    }
   }
 }
 

--- a/src/pages/Market/MarketChart.tsx
+++ b/src/pages/Market/MarketChart.tsx
@@ -61,7 +61,9 @@ function MarketOverview() {
                 </Text>
               </>
             ) : (
-              `${highestPriceOutcome.price} ${ticker}`
+              <span className="notranslate">
+                {highestPriceOutcome.price} {ticker}
+              </span>
             )}
           </Text>
           <Text

--- a/src/pages/Market/MarketChart.tsx
+++ b/src/pages/Market/MarketChart.tsx
@@ -57,7 +57,6 @@ function MarketOverview() {
                   className="market-chart__view-caption"
                 >
                   <InfoTooltip text="Probability of an answer occur based on already made predictions." />
-                  Probability
                 </Text>
               </>
             ) : (

--- a/src/pages/Market/MarketChart.tsx
+++ b/src/pages/Market/MarketChart.tsx
@@ -7,7 +7,7 @@ import sortOutcomes from 'helpers/sortOutcomes';
 import maxBy from 'lodash/maxBy';
 import { useTheme } from 'ui';
 
-import { ChartHeader, LineChart, Text } from 'components';
+import { ChartHeader, InfoTooltip, LineChart, Text } from 'components';
 
 import { useAppSelector } from 'hooks';
 
@@ -44,18 +44,24 @@ function MarketOverview() {
           >
             {highestPriceOutcome.title.toUpperCase()}
           </Text>
-          <Text
-            color="light-gray"
-            scale="heading"
-            fontWeight="semibold"
-            className="notranslate"
-          >
+          <Text color="light-gray" scale="heading" fontWeight="semibold">
             {features.fantasy.enabled ? (
-              <>{roundNumber(highestPriceOutcome.price * 100, 3)}%</>
-            ) : (
               <>
-                {highestPriceOutcome.price} {ticker}
+                <span className="notranslate">
+                  {roundNumber(highestPriceOutcome.price * 100, 3)}%
+                </span>
+                <Text
+                  as="span"
+                  scale="tiny-uppercase"
+                  fontWeight="bold"
+                  className="market-chart__view-caption"
+                >
+                  <InfoTooltip text="Probability of an answer occur based on already made predictions." />
+                  Probability
+                </Text>
               </>
+            ) : (
+              `${highestPriceOutcome.price} ${ticker}`
             )}
           </Text>
           <Text

--- a/src/pages/Market/MarketPredictions.tsx
+++ b/src/pages/Market/MarketPredictions.tsx
@@ -4,6 +4,7 @@ import { reset, selectOutcome } from 'redux/ducks/trade';
 import { useTheme } from 'ui';
 
 import {
+  InfoTooltip,
   Modal,
   ModalContent,
   ModalHeader,
@@ -65,7 +66,13 @@ function MarketPredictions() {
       <MarketTransactions />
       <MarketShares onSellSelected={handlePredictionSelected} />
       <div className={styles.predictions}>
-        <p className={styles.predictionsTitle}>Select your prediction</p>
+        <p className={styles.predictionsTitle}>
+          Select your prediction{' '}
+          <span className={styles.predictionsTitleCaption}>
+            <InfoTooltip text="Probability of an answer occur based on already made predictions." />
+            Probability (%)
+          </span>
+        </p>
         <TradePredictions
           view="default"
           size="lg"

--- a/src/pages/Market/MarketPredictions.tsx
+++ b/src/pages/Market/MarketPredictions.tsx
@@ -69,7 +69,6 @@ function MarketPredictions() {
         <p className={styles.predictionsTitle}>
           Select your prediction{' '}
           <span className={styles.predictionsTitleCaption}>
-            <InfoTooltip text="Probability of an answer occur based on already made predictions." />
             Probability (%)
           </span>
         </p>

--- a/src/styles/components/_market.scss
+++ b/src/styles/components/_market.scss
@@ -61,6 +61,11 @@
       &-title {
         color: themed('chart-view-title-color');
       }
+
+      &-caption {
+        color: var(--color-text-secondary);
+        vertical-align: middle;
+      }
     }
   }
 }


### PR DESCRIPTION
## 🗃 Story Description

[ENG-221](https://linear.app/polkamarkets-labs/issue/ENG-221/tornar-claro-o-conceito-de-probabilidade-no-previsometro) 

## 🧪 Test Suite
- Navbar Actions
  - [ ] Switch between light and dark mode across pages
  - [ ] Network Switcher
  - [ ] Wrong Network Modal
- Homepage Markets Navigation
  - [ ] Filters
  - [ ] Sorting
  - [ ] Search
- Pages Content
  - [ ] Homepage
  - [ ] Create Market Page
  - [ ] Market Page
  - [ ] Portfolio
- Trading (**Optional** - only if PR involves related components or `polkamarkets-js`)
  - [ ] Slider + MAX button
  - [ ] Buy Outcome Shares
  - [ ] Sell Outcome Shares
  - [ ] Add Liquidity 
  - [ ] Remove Liquidity
 
  ## 📝 Footnotes
  _Noting to add._
